### PR TITLE
fix: update header subtitle to replace Kafka with GCP

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -12,7 +12,7 @@ export default function Header() {
       <div>
         <h1 className="text-4xl font-bold">Sherard Bailey</h1>
         <p className="text-lg mt-2 text-gray-600 dark:text-gray-400">
-          Senior Software Engineer —  Microservices | Event-driven Architecture | AWS | Kafka
+          Senior Software Engineer —  Microservices | Event-driven Architecture | AWS | GCP 
         </p>
         <div className="flex justify-center md:justify-start gap-4 mt-4">
           <a href="https://www.linkedin.com/in/sherardbailey" target="_blank" aria-label="LinkedIn">


### PR DESCRIPTION
## Summary
- Updated the header tagline to replace "Kafka" with "GCP"
- Fixed missing newline at end of file

## Test plan
- [ ] Verify the header displays "Senior Software Engineer — Microservices | Event-driven Architecture | AWS | GCP"
- [ ] Confirm no layout or styling regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)