### PR TITLE
fix(infra): add Route53 DNS records for SES domain verification

### DIFF
--- a/infra/recruiter-dashboard/main.tf
+++ b/infra/recruiter-dashboard/main.tf
@@ -122,6 +122,7 @@ module "ses" {
   ses_domain                = var.ses_domain
   ses_recipient             = var.ses_recipient
   aws_region                = var.aws_region
+  hosted_zone_id            = var.hosted_zone_id
   s3_bucket_name            = module.s3.bucket_name
   email_parser_function_arn = module.lambda_email_parser.function_arn
 }

--- a/infra/recruiter-dashboard/modules/ses/main.tf
+++ b/infra/recruiter-dashboard/modules/ses/main.tf
@@ -11,6 +11,41 @@ resource "aws_ses_domain_dkim" "this" {
 }
 
 # ---------------------------------------------------------------------------
+# Route53 DNS Records — domain verification, DKIM, and MX
+# ---------------------------------------------------------------------------
+
+resource "aws_route53_record" "ses_verification" {
+  zone_id = var.hosted_zone_id
+  name    = "_amazonses.${var.ses_domain}"
+  type    = "TXT"
+  ttl     = 600
+  records = [aws_ses_domain_identity.this.verification_token]
+}
+
+resource "aws_route53_record" "ses_dkim" {
+  count   = 3
+  zone_id = var.hosted_zone_id
+  name    = "${aws_ses_domain_dkim.this.dkim_tokens[count.index]}._domainkey.${var.ses_domain}"
+  type    = "CNAME"
+  ttl     = 600
+  records = ["${aws_ses_domain_dkim.this.dkim_tokens[count.index]}.dkim.amazonses.com"]
+}
+
+resource "aws_route53_record" "ses_mx" {
+  zone_id = var.hosted_zone_id
+  name    = var.ses_domain
+  type    = "MX"
+  ttl     = 600
+  records = ["10 inbound-smtp.${var.aws_region}.amazonaws.com"]
+}
+
+resource "aws_ses_domain_identity_verification" "this" {
+  domain = aws_ses_domain_identity.this.id
+
+  depends_on = [aws_route53_record.ses_verification]
+}
+
+# ---------------------------------------------------------------------------
 # SES Receipt Rule Set
 # ---------------------------------------------------------------------------
 

--- a/infra/recruiter-dashboard/modules/ses/outputs.tf
+++ b/infra/recruiter-dashboard/modules/ses/outputs.tf
@@ -17,3 +17,8 @@ output "ses_domain" {
   description = "The SES domain name."
   value       = aws_ses_domain_identity.this.domain
 }
+
+output "domain_verification_status" {
+  description = "SES domain verification status."
+  value       = aws_ses_domain_identity_verification.this.id
+}

--- a/infra/recruiter-dashboard/modules/ses/variables.tf
+++ b/infra/recruiter-dashboard/modules/ses/variables.tf
@@ -23,6 +23,11 @@ variable "email_parser_function_arn" {
   type        = string
 }
 
+variable "hosted_zone_id" {
+  description = "Route53 hosted zone ID for DNS record creation."
+  type        = string
+}
+
 variable "s3_key_prefix" {
   description = "S3 key prefix for stored emails."
   type        = string

--- a/infra/recruiter-dashboard/outputs.tf
+++ b/infra/recruiter-dashboard/outputs.tf
@@ -43,17 +43,7 @@ output "api_endpoint" {
   value       = module.api_gateway.api_endpoint
 }
 
-output "ses_domain_verification_token" {
-  description = "TXT record value for SES domain verification."
-  value       = module.ses.domain_verification_token
-}
-
-output "ses_dkim_tokens" {
-  description = "DKIM CNAME record tokens for email signing."
-  value       = module.ses.dkim_tokens
-}
-
-output "ses_mx_record" {
-  description = "MX record value to route inbound email to SES."
-  value       = module.ses.mx_record
+output "ses_domain_verification_status" {
+  description = "SES domain verification status (domain name when verified)."
+  value       = module.ses.domain_verification_status
 }

--- a/infra/recruiter-dashboard/terraform.tfvars.example
+++ b/infra/recruiter-dashboard/terraform.tfvars.example
@@ -27,3 +27,6 @@ log_retention_days = 7
 
 # S3 lifecycle expiration in days for raw emails
 s3_lifecycle_expiration_days = 30
+
+# Route53 hosted zone ID for SES DNS records
+hosted_zone_id = "Z0123456789ABCDEFGHIJ"

--- a/infra/recruiter-dashboard/variables.tf
+++ b/infra/recruiter-dashboard/variables.tf
@@ -84,6 +84,16 @@ variable "s3_lifecycle_expiration_days" {
   default     = 30
 }
 
+variable "hosted_zone_id" {
+  description = "Route53 hosted zone ID for SES DNS record creation."
+  type        = string
+
+  validation {
+    condition     = can(regex("^Z[A-Z0-9]+$", var.hosted_zone_id))
+    error_message = "Must be a valid Route53 hosted zone ID (starts with Z, alphanumeric)."
+  }
+}
+
 variable "default_tags" {
   description = "Default tags applied to all resources."
   type        = map(string)


### PR DESCRIPTION
## Summary
- Add Route53 TXT, CNAME (x3), and MX records to the SES module for automated domain verification and DKIM setup
- Add `aws_ses_domain_identity_verification` waiter to block `terraform apply` until SES confirms verification
- Replace manual DNS token outputs (`ses_domain_verification_token`, `ses_dkim_tokens`, `ses_mx_record`) with a single `ses_domain_verification_status` output
- Add `hosted_zone_id` variable to SES module and root module with validation

## Test plan
- [ ] `terraform fmt -recursive` passes with no changes
- [ ] `terraform validate` succeeds
- [ ] `terraform plan` shows 5 new Route53 records + 1 verification waiter (no destructive changes)
- [ ] After `terraform apply`, verify with `aws ses get-identity-verification-attributes --identities inbox.sh3r4rd.com --region us-east-1`
- [ ] If SES status was "Failed", run `aws ses verify-domain-identity --domain inbox.sh3r4rd.com --region us-east-1` to re-trigger, then re-apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)