### PR TITLE
docs: add codex cli setup guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This file provides repository-specific guidance to Codex CLI when working in thi
 ## Scope
 
 - Keep this file Codex-specific. Do not treat it as the source of truth for Claude Code or Copilot.
-- Preserve existing guidance in [CLAUDE.md](/Users/sherardbailey/Code/sh3r4rd.com/CLAUDE.md) and [.github/copilot-instructions.md](/Users/sherardbailey/Code/sh3r4rd.com/.github/copilot-instructions.md).
+- Preserve existing guidance in [CLAUDE.md](CLAUDE.md) and [.github/copilot-instructions.md](.github/copilot-instructions.md).
 
 ## Project Overview
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ This repository uses [conventional commits](https://www.conventionalcommits.org/
 
 This repository includes tool-specific instructions for multiple coding assistants:
 
-- Claude Code reads [CLAUDE.md](/Users/sherardbailey/Code/sh3r4rd.com/CLAUDE.md)
-- Codex CLI reads [AGENTS.md](/Users/sherardbailey/Code/sh3r4rd.com/AGENTS.md)
-- GitHub Copilot reads [.github/copilot-instructions.md](/Users/sherardbailey/Code/sh3r4rd.com/.github/copilot-instructions.md) and any scoped instructions under [.github/instructions/](/Users/sherardbailey/Code/sh3r4rd.com/.github/instructions)
+- Claude Code reads [CLAUDE.md](CLAUDE.md)
+- Codex CLI reads [AGENTS.md](AGENTS.md)
+- GitHub Copilot reads [.github/copilot-instructions.md](.github/copilot-instructions.md) and any scoped instructions under [.github/instructions/](.github/instructions/)
 
-Developers using Codex should start with [docs/codex.md](/Users/sherardbailey/Code/sh3r4rd.com/docs/codex.md) for installation, ChatGPT sign-in, repository workflow, and validation expectations.
+Developers using Codex should start with [docs/codex.md](docs/codex.md) for installation, ChatGPT sign-in, repository workflow, and validation expectations.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -33,7 +33,7 @@ From the repository root:
 codex
 ```
 
-Codex will automatically read repository guidance from [AGENTS.md](/Users/sherardbailey/Code/sh3r4rd.com/AGENTS.md). That file is intentionally Codex-specific. If you are using Claude Code or Copilot, use their own instruction files instead.
+Codex will automatically read repository guidance from [AGENTS.md](../AGENTS.md). That file is intentionally Codex-specific. If you are using Claude Code or Copilot, use their own instruction files instead.
 
 ## Recommended Workflow
 
@@ -89,6 +89,6 @@ Read approval prompts carefully and grant them only when the action matches the 
 
 ## Related Files
 
-- Codex instructions: [AGENTS.md](/Users/sherardbailey/Code/sh3r4rd.com/AGENTS.md)
-- Claude Code instructions: [CLAUDE.md](/Users/sherardbailey/Code/sh3r4rd.com/CLAUDE.md)
-- Copilot instructions: [.github/copilot-instructions.md](/Users/sherardbailey/Code/sh3r4rd.com/.github/copilot-instructions.md)
+- Codex instructions: [AGENTS.md](../AGENTS.md)
+- Claude Code instructions: [CLAUDE.md](../CLAUDE.md)
+- Copilot instructions: [.github/copilot-instructions.md](../.github/copilot-instructions.md)


### PR DESCRIPTION
## Summary
- add Codex-specific repository instructions in AGENTS.md
- document Codex CLI setup in docs/codex.md
- link the new Codex guide from README.md

## Testing
- not run (docs-only changes)