### PR TITLE
fix(ci): use SSH deploy key to bypass branch ruleset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- Replace PAT (`RELEASE_TOKEN`) with an SSH deploy key for `@semantic-release/git` push operations
- Deploy keys are first-class bypass actors in GitHub rulesets, unlike PATs which don't reliably inherit role-based bypass in CI
- Add SSH `repositoryUrl` to `.releaserc.json` so semantic-release pushes via the deploy key
- Use default `GITHUB_TOKEN` for GitHub API operations (creating releases)

## Setup required
- [x] Deploy key added to repo with write access
- [x] Private key stored as `DEPLOY_KEY` secret
- [ ] Enable "Deploy keys" bypass in ruleset (Settings > Rules > Protect Main)

## Test plan
- [ ] Merge and verify the Release workflow succeeds on the next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)