### PR TITLE
feat(page): add DashboardPage with data fetching and route (#37)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import PageTracker from "./components/layout/PageTracker";
 import HomePage from "./pages/HomePage";
 import ResumeRequestPage from "./pages/ResumeRequestPage";
+import DashboardPage from "./pages/DashboardPage";
 import NotFoundPage from "./pages/NotFoundPage";
 
 export default function App() {
@@ -12,6 +13,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/resume" element={<ResumeRequestPage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </Router>

--- a/src/components/sections/FilterBar.jsx
+++ b/src/components/sections/FilterBar.jsx
@@ -1,17 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Search } from "lucide-react";
 import { Button } from "../ui/button";
+import { EMPTY_FILTERS } from "../../lib/filters";
 
 const inputClass =
   "p-2 border border-gray-300 dark:border-gray-700 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100";
-
-const EMPTY_FILTERS = {
-  search: "",
-  company: "",
-  jobTitle: "",
-  monthFrom: "",
-  monthTo: "",
-};
 
 // `allData` must be the unfiltered recruiter list — dropdown options are
 // derived from it, so passing a filtered list would collapse the options
@@ -72,13 +65,7 @@ export default function FilterBar({
   );
 
   const handleClear = () => {
-    onFilterChange({
-      search: "",
-      company: "",
-      jobTitle: "",
-      monthFrom: "",
-      monthTo: "",
-    });
+    onFilterChange({ ...EMPTY_FILTERS });
   };
 
   return (

--- a/src/lib/filters.js
+++ b/src/lib/filters.js
@@ -1,0 +1,10 @@
+// Shared empty/default state for the recruiter dashboard filters.
+// Imported by both DashboardPage (initial state / reset) and FilterBar
+// (default prop) so the filter shape has a single source of truth.
+export const EMPTY_FILTERS = {
+  search: "",
+  company: "",
+  jobTitle: "",
+  monthFrom: "",
+  monthTo: "",
+};

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AlertCircle, Loader2, RefreshCw } from "lucide-react";
+import { Button } from "../components/ui/button";
+import Breadcrumbs from "../components/layout/Breadcrumbs";
+import Header from "../components/layout/Header";
+import StatsCards from "../components/sections/StatsCards";
+import FilterBar from "../components/sections/FilterBar";
+import RecruiterTable from "../components/sections/RecruiterTable";
+
+const API_URL = "https://api.sh3r4rd.com/recruiters";
+const PAGE_SIZE = 10;
+
+const EMPTY_FILTERS = {
+  search: "",
+  company: "",
+  jobTitle: "",
+  monthFrom: "",
+  monthTo: "",
+};
+
+function matchesFilters(item, filters) {
+  const { search, company, jobTitle, monthFrom, monthTo } = filters;
+
+  if (company && item.company !== company) return false;
+  if (jobTitle && item.jobTitle !== jobTitle) return false;
+
+  if (search) {
+    const needle = search.toLowerCase();
+    const haystack = `${item.company ?? ""} ${item.jobTitle ?? ""}`.toLowerCase();
+    if (!haystack.includes(needle)) return false;
+  }
+
+  if (monthFrom && (item.month ?? "") < monthFrom) return false;
+  if (monthTo && (item.month ?? "") > monthTo) return false;
+
+  return true;
+}
+
+export default function DashboardPage() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [filters, setFilters] = useState(EMPTY_FILTERS);
+  const [page, setPage] = useState(1);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(API_URL);
+      if (!res.ok) {
+        throw new Error(`Request failed: ${res.status}`);
+      }
+      const body = await res.json();
+      setData(Array.isArray(body) ? body : []);
+    } catch (err) {
+      setError(err.message || "Failed to load recruiter data");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const filteredData = useMemo(
+    () => data.filter((item) => matchesFilters(item, filters)),
+    [data, filters],
+  );
+
+  const handleFilterChange = useCallback((nextFilters) => {
+    setFilters(nextFilters);
+    setPage(1);
+  }, []);
+
+  const handleRefresh = () => {
+    setRefreshing(true);
+    loadData();
+  };
+
+  const filtersActive = useMemo(
+    () => Object.values(filters).some((v) => v !== ""),
+    [filters],
+  );
+
+  return (
+    <section className="max-w-4xl mx-auto space-y-12">
+      <Breadcrumbs />
+      <Header />
+
+      <section className="space-y-6">
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <h2 className="text-2xl font-semibold">Recruiter Dashboard</h2>
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={loading || refreshing}
+            className="inline-flex items-center gap-2 px-3 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <RefreshCw
+              className={`w-4 h-4 ${refreshing ? "animate-spin" : ""}`}
+            />
+            Refresh
+          </button>
+        </div>
+
+        {loading && !refreshing ? (
+          <div className="flex flex-col items-center justify-center py-16 text-gray-600 dark:text-gray-400">
+            <Loader2 className="w-8 h-8 animate-spin" />
+            <p className="mt-4">Loading recruiter data...</p>
+          </div>
+        ) : error ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <AlertCircle className="w-10 h-10 text-red-500 dark:text-red-400" />
+            <p className="mt-4 text-gray-700 dark:text-gray-300">{error}</p>
+            <div className="mt-4">
+              <Button onClick={handleRefresh}>Try Again</Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <StatsCards data={data} />
+
+            <FilterBar
+              data={data}
+              filters={filters}
+              onFilterChange={handleFilterChange}
+            />
+
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {filtersActive
+                ? `${filteredData.length} results (filtered from ${data.length})`
+                : `${data.length} results`}
+            </p>
+
+            <RecruiterTable
+              data={filteredData}
+              page={page}
+              pageSize={PAGE_SIZE}
+              onPageChange={setPage}
+            />
+          </>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -6,17 +6,11 @@ import Header from "../components/layout/Header";
 import StatsCards from "../components/sections/StatsCards";
 import FilterBar from "../components/sections/FilterBar";
 import RecruiterTable from "../components/sections/RecruiterTable";
+import { EMPTY_FILTERS } from "../lib/filters";
 
-const API_URL = "https://api.sh3r4rd.com/recruiters";
+const RECRUITERS_URL = "https://api.sh3r4rd.com/recruiters";
+const STATS_URL = "https://api.sh3r4rd.com/stats";
 const PAGE_SIZE = 10;
-
-const EMPTY_FILTERS = {
-  search: "",
-  company: "",
-  jobTitle: "",
-  monthFrom: "",
-  monthTo: "",
-};
 
 function matchesFilters(item, filters) {
   const { search, company, jobTitle, monthFrom, monthTo } = filters;
@@ -38,6 +32,7 @@ function matchesFilters(item, filters) {
 
 export default function DashboardPage() {
   const [data, setData] = useState([]);
+  const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [filters, setFilters] = useState(EMPTY_FILTERS);
@@ -48,12 +43,17 @@ export default function DashboardPage() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(API_URL);
-      if (!res.ok) {
-        throw new Error(`Request failed: ${res.status}`);
+      const [recruitersRes, statsRes] = await Promise.all([
+        fetch(RECRUITERS_URL),
+        fetch(STATS_URL),
+      ]);
+      if (!recruitersRes.ok) {
+        throw new Error(`Request failed: ${recruitersRes.status}`);
       }
-      const body = await res.json();
+      const body = await recruitersRes.json();
       setData(Array.isArray(body) ? body : []);
+      // Stats are supplementary; a stats failure shouldn't blank the table.
+      setStats(statsRes.ok ? await statsRes.json() : null);
     } catch (err) {
       setError(err.message || "Failed to load recruiter data");
     } finally {
@@ -117,15 +117,15 @@ export default function DashboardPage() {
             <AlertCircle className="w-10 h-10 text-red-500 dark:text-red-400" />
             <p className="mt-4 text-gray-700 dark:text-gray-300">{error}</p>
             <div className="mt-4">
-              <Button onClick={handleRefresh}>Try Again</Button>
+              <Button onClick={loadData}>Try Again</Button>
             </div>
           </div>
         ) : (
           <>
-            <StatsCards data={data} />
+            <StatsCards stats={stats} />
 
             <FilterBar
-              data={data}
+              allData={data}
               filters={filters}
               onFilterChange={handleFilterChange}
             />


### PR DESCRIPTION
## Summary
- Adds `src/pages/DashboardPage.jsx` and the `/dashboard` route in `src/App.jsx`
- Owns shared state (`data`, `loading`, `error`, `filters`, `page`) and wires up the three Phase 4 child components
- Client-side filter logic: text search across `company`+`jobTitle`, exact-match company/job-title dropdowns, and a `monthFrom`/`monthTo` range against the API's `YYYY-MM` month field
- Renders loading, error (with Try Again), and refresh-while-loaded states
- Refresh button re-fetches without resetting filters or page

Closes #37. Part of #19.

## Dependencies
This PR imports `StatsCards`, `FilterBar`, and `RecruiterTable` from `src/components/sections/`. Those components are added by:
- #80 (`feat/34-stats-cards`)
- #82 (`feat/35-filter-bar`)
- #81 (`feat/36-recruiter-table`)

**CI on this PR will fail until those three are merged into `epic/phase-4-dashboard-frontend`.** Local verification was done by checking the components out into the working tree, running `npm run lint && npm run build && npm run dev`, and confirming the `/dashboard` route returns 200 with the SPA shell — then removing the temp files before committing.

## Deviations from spec
The issue references `dateFrom`/`dateTo` as `<input type="date">` and an `anonymizeName(firstName, lastName)` helper. Neither is implemented because the Phase 3 API exposes only `month` (`YYYY-MM`) and never returns `firstName`/`lastName`. Decision logged in `.claude/plans/implementation-notes.md`.

## Test plan
- [ ] After #80/#81/#82 merge into the epic, rebase this branch and re-run CI
- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] Manual: `/dashboard` shows loading → stats/filters/table once the API responds; refresh button re-fetches; clear filters resets page to 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)