### PR TITLE
feat(dashboard): recruiter dashboard frontend (Phase 4)

### DIFF
--- a/.claude/plans/implementation-notes.md
+++ b/.claude/plans/implementation-notes.md
@@ -56,18 +56,43 @@ Linear/`linear-workflow` skill not used — this repo tracks issues on GitHub, n
 
 ## Open items / follow-ups
 
-_(None yet — will track here as I encounter them.)_
+- **PR #83 will not pass CI until PRs #80, #81, #82 merge into the epic.** Its imports of the three sibling components only resolve after those land. Plan: rebase #83 once the three components are in.
+- Worktrees from the parallel agent runs at `.claude/worktrees/agent-*` were locked by the agent harness when I tried to clean them up. They auto-clean on agent exit. They're now gitignored and eslint-ignored so they shouldn't interfere.
+- The existing `src/pages/ResumeRequestPage.jsx` inputs use `text-black` (no dark-mode variant). Out of scope for Phase 4 but worth a small follow-up — Phase 4 inputs (FilterBar) use the dark-aware pattern `bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100`.
+
+## Infrastructure pushed directly to the epic branch
+
+Three small commits went straight to `epic/phase-4-dashboard-frontend` (not as subtask PRs) because they're cross-cutting setup, not feature work:
+
+1. `chore(plans): add Phase 4 implementation notes and ignore agent worktrees` — adds this file and gitignores `.claude/worktrees/`.
+2. `chore(lint): ignore .claude/ in eslint global ignores` — keeps lint from scanning agent worktree dist bundles.
+
+These don't belong in any subtask PR's scope.
 
 ## Per-subtask notes
 
-### #34 — StatsCards
-_(updates as work progresses)_
+### #34 — StatsCards → PR #80
+- Implemented by parallel subagent in worktree isolation. Lint + build clean.
+- Subagent deviation worth knowing: it initially passed icons as `Icon` props and rendered `<Icon />`, but the project's eslint config (`no-unused-vars` with `varsIgnorePattern: '^[A-Z_]'`) doesn't have a React plugin to recognize JSX usage of capitalized identifiers, so `Icon` was flagged unused. Refactor: store pre-rendered `<Mail .../>` elements directly in the card config. Same visual output.
 
-### #35 — FilterBar
-_(updates as work progresses)_
+### #35 — FilterBar → PR #82
+- Implemented by parallel subagent in worktree isolation. Lint + build clean.
+- Date range reinterpreted as month range (`<input type="month">`) because the API exposes only `month: "YYYY-MM"`. See top-of-file decision #1.
+- Two `useEffect`s for the debounce: one for local→parent push (200ms), one to sync local state back from parent when filters are cleared externally. Both have a targeted `eslint-disable-next-line react-hooks/exhaustive-deps` with a one-line rationale.
 
-### #36 — RecruiterTable
-_(updates as work progresses)_
+### #36 — RecruiterTable → PR #81
+- Implemented by parallel subagent in worktree isolation. Lint + build clean.
+- Dropped the spec's `anonymizeName(firstName, lastName)` helper — API already returns `recruiterLabel` in anonymized form. See top-of-file decision #1.
+- Default sort: `month` descending. Sort state lives inside the component; pagination state is owned by the parent (per the prop contract).
+- Optional mobile sort `<select>` from the spec was skipped (spec said optional).
+- Defensive clamp on `currentPage` when filtered data shrinks below the current page.
 
-### #37 — DashboardPage
-_(updates as work progresses)_
+### #37 — DashboardPage → PR #83
+- Implemented sequentially in the main worktree after #34/#35/#36 were on their branches.
+- Local verification approach: temporarily checked the three components into the working tree via `git show feat/34-stats-cards:... > ...` (one per sibling), ran `npm run lint && npm run build && npm run dev`, curled `/dashboard` (got HTTP 200 + SPA shell), then `rm`'d the temp files before staging the actual commit. Final commit has only `src/pages/DashboardPage.jsx` + `src/App.jsx`.
+- Did not test against the real API end-to-end. Loading/error states verified by visual code review only; live-data flows will need verification after the components merge into the epic and the page builds with real imports.
+- Filter logic decisions:
+  - Search is a `toLowerCase().includes(...)` substring match across the concatenation of `company + " " + jobTitle` (no name field exists in the API).
+  - Company / jobTitle dropdowns do exact equality on `item.company === filters.company` (the dropdown values come from the dataset itself, so exact equality is correct).
+  - Month range: lexical comparison on `YYYY-MM` strings — correct because the format sorts naturally.
+- `EMPTY_FILTERS` constant + `setFilters(EMPTY_FILTERS)` in the clear path; `setPage(1)` is called by the parent's `handleFilterChange` so the FilterBar doesn't need to know about pagination.

--- a/.claude/plans/implementation-notes.md
+++ b/.claude/plans/implementation-notes.md
@@ -1,0 +1,73 @@
+# Phase 4: Dashboard Frontend — Implementation Notes
+
+Running log of decisions, deviations from issue specs, and tradeoffs made while implementing issue [#19](https://github.com/sh3r4rd/sh3r4rd.com/issues/19) and subtasks #34, #35, #36, #37.
+
+Base branch: `epic/phase-4-dashboard-frontend` (off `main`). All subtask PRs target this branch.
+
+## Decisions
+
+### 1. Data shape — match the real API, not the issue specs (2026-05-25)
+
+The Phase 4 issues were drafted before the Phase 3 API was finalized, and the two diverge:
+
+| Field referenced in issues | Field actually returned by `/recruiters` (Phase 3 `AnonymizedItem`) |
+|---|---|
+| `firstName`, `lastName` (with client-side `anonymizeName` → "Jane S.") | _not returned_ — stripped server-side in `anonymizer.go` |
+| `dateReceived` (full date) | `month` (coarsened to `YYYY-MM`) |
+| — | `recruiterLabel` ("Recruiter at {Company}") |
+| — | `confidence` |
+
+**Decision:** Render the API response verbatim — use `recruiterLabel` for the recruiter column and `month` for the date column. No client-side anonymization helper; the backend already does that.
+
+**Why:** The Phase 3 anonymization is deliberate (issue #18 AC: "API responses NEVER contain recruiter email, phone, or full name"). Sending first/last names to the client and anonymizing there would re-introduce the very PII the backend strips. The issue specs in #36 are stale — flagged but not blocking.
+
+**Affected subtasks:**
+- **#36 (RecruiterTable):** Columns become Company, Job Title, Recruiter (renders `recruiterLabel`), Month. No `anonymizeName` helper.
+- **#35 (FilterBar):** Search filter applies to `company` and `jobTitle` only (no name field exists). "Job Title dropdown" still derived from `jobTitle`.
+- **#34 (StatsCards):** "This Month" computed against `month` field (YYYY-MM compare), not a Date.
+- **#37 (DashboardPage):** Filtered fields are `{ search, company, jobTitle, monthFrom, monthTo }` instead of `{ dateFrom, dateTo }`. Date range inputs use `month` type, not `date`.
+
+### 2. Access — public route, no auth (2026-05-25)
+
+`/dashboard` is publicly accessible. No auth gate. Data is fully anonymized server-side, and the existing site has no auth infrastructure. Adding auth was deemed scope creep on Phase 4.
+
+### 3. API base URL — hardcoded (2026-05-25)
+
+`https://api.sh3r4rd.com` hardcoded in the fetch call, matching the existing pattern in `ResumeRequestPage.jsx`. No Vite env var introduced — single-environment site, no staging.
+
+### 4. Branch & PR strategy (2026-05-25)
+
+- Each subtask has its own `feat/{n}-{slug}` branch off `epic/phase-4-dashboard-frontend`.
+- Each PR targets `epic/phase-4-dashboard-frontend`, NOT `main`.
+- #34, #35, #36 are independent components — implemented in **parallel via subagents with worktree isolation**.
+- #37 is implemented sequentially after the other three (depends on importing them).
+- #37's CI/build will fail until #34, #35, #36 are merged into the epic — flagged in the PR description.
+
+### 5. Subagent / skill mapping (2026-05-25)
+
+| Task | Tool | Why |
+|---|---|---|
+| Parallel build of #34, #35, #36 | `general-purpose` agent × 3 with `isolation: "worktree"` | Independent components — no shared files; agents can work in isolated trees simultaneously. |
+| Final build of #37 | Done in main worktree (sequential) | Imports the other three components; easier to verify all wired up locally before splitting commits. |
+| Build / lint verification | `npm run lint && npm run build` inside each worktree | Each agent verifies their own component compiles. |
+| `feature-dev:code-reviewer` | Reserved for post-implementation review of #37 if it grows complex. | Optional — only if the page logic warrants a second pass. |
+
+Linear/`linear-workflow` skill not used — this repo tracks issues on GitHub, no `.linear/` directory.
+
+## Open items / follow-ups
+
+_(None yet — will track here as I encounter them.)_
+
+## Per-subtask notes
+
+### #34 — StatsCards
+_(updates as work progresses)_
+
+### #35 — FilterBar
+_(updates as work progresses)_
+
+### #36 — RecruiterTable
+_(updates as work progresses)_
+
+### #37 — DashboardPage
+_(updates as work progresses)_

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dist-ssr
 
 # Claude Code
 .claude/settings.local.json
+.claude/worktrees/
 
 # Scratch/experimentation
 scratch/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', '.claude']),
   {
     files: ['**/*.{js,jsx}'],
     extends: [

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import PageTracker from "./components/layout/PageTracker";
 import HomePage from "./pages/HomePage";
 import ResumeRequestPage from "./pages/ResumeRequestPage";
+import DashboardPage from "./pages/DashboardPage";
 import NotFoundPage from "./pages/NotFoundPage";
 
 export default function App() {
@@ -12,6 +13,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/resume" element={<ResumeRequestPage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </Router>

--- a/src/components/sections/FilterBar.jsx
+++ b/src/components/sections/FilterBar.jsx
@@ -65,6 +65,12 @@ export default function FilterBar({
   );
 
   const handleClear = () => {
+    // Reset local input too. Without this, clearing while a debounce is still
+    // pending (parent's `filters.search` not yet updated) leaves `searchInput`
+    // stale, so the sync effect never fires and the pending timer re-applies the
+    // old search. Setting it here re-runs the debounce effect, whose cleanup
+    // clears that timer.
+    setSearchInput("");
     onFilterChange({ ...EMPTY_FILTERS });
   };
 

--- a/src/components/sections/FilterBar.jsx
+++ b/src/components/sections/FilterBar.jsx
@@ -1,17 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Search } from "lucide-react";
 import { Button } from "../ui/button";
+import { EMPTY_FILTERS } from "../../lib/filters";
 
 const inputClass =
   "p-2 border border-gray-300 dark:border-gray-700 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100";
-
-const EMPTY_FILTERS = {
-  search: "",
-  company: "",
-  jobTitle: "",
-  monthFrom: "",
-  monthTo: "",
-};
 
 // `allData` must be the unfiltered recruiter list — dropdown options are
 // derived from it, so passing a filtered list would collapse the options
@@ -72,13 +65,7 @@ export default function FilterBar({
   );
 
   const handleClear = () => {
-    onFilterChange({
-      search: "",
-      company: "",
-      jobTitle: "",
-      monthFrom: "",
-      monthTo: "",
-    });
+    onFilterChange({ ...EMPTY_FILTERS });
   };
 
   return (

--- a/src/components/sections/FilterBar.jsx
+++ b/src/components/sections/FilterBar.jsx
@@ -1,0 +1,171 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Search } from "lucide-react";
+import { Button } from "../ui/button";
+
+const inputClass =
+  "p-2 border border-gray-300 dark:border-gray-700 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100";
+
+const EMPTY_FILTERS = {
+  search: "",
+  company: "",
+  jobTitle: "",
+  monthFrom: "",
+  monthTo: "",
+};
+
+// `allData` must be the unfiltered recruiter list — dropdown options are
+// derived from it, so passing a filtered list would collapse the options
+// as the user drills in.
+export default function FilterBar({
+  allData,
+  filters = EMPTY_FILTERS,
+  onFilterChange,
+}) {
+  const [searchInput, setSearchInput] = useState(filters.search);
+
+  // Mirror latest filters in a ref so the debounced timer merges against
+  // fresh state instead of a stale closure snapshot.
+  const filtersRef = useRef(filters);
+  useEffect(() => {
+    filtersRef.current = filters;
+  }, [filters]);
+
+  // Debounce search input changes (200ms) before pushing up to parent.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      if (searchInput !== filtersRef.current.search) {
+        onFilterChange({ ...filtersRef.current, search: searchInput });
+      }
+    }, 200);
+    return () => clearTimeout(t);
+    // Debounce should react only to local input changes, not to filter resets
+    // pushed in from the parent (e.g. Clear Filters). The sync effect below
+    // handles those cases.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchInput]);
+
+  // If parent resets search externally (e.g. Clear Filters), sync local state.
+  useEffect(() => {
+    if (filters.search !== searchInput) {
+      setSearchInput(filters.search);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters.search]);
+
+  const companyOptions = useMemo(
+    () => [...new Set((allData || []).map((r) => r.company).filter(Boolean))].sort(),
+    [allData],
+  );
+  const jobTitleOptions = useMemo(
+    () => [...new Set((allData || []).map((r) => r.jobTitle).filter(Boolean))].sort(),
+    [allData],
+  );
+
+  // Use `searchInput` (not `filters.search`) so the Clear button reflects the
+  // user's intent immediately instead of lagging the 200ms debounce.
+  const hasActiveFilters = Boolean(
+    searchInput ||
+      filters.company ||
+      filters.jobTitle ||
+      filters.monthFrom ||
+      filters.monthTo,
+  );
+
+  const handleClear = () => {
+    onFilterChange({
+      search: "",
+      company: "",
+      jobTitle: "",
+      monthFrom: "",
+      monthTo: "",
+    });
+  };
+
+  return (
+    <section className="space-y-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <div className="relative">
+          <Search
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 dark:text-gray-400 pointer-events-none"
+            aria-hidden="true"
+          />
+          <input
+            type="text"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search company or job title…"
+            aria-label="Search company or job title"
+            className={`${inputClass} pl-9 w-full`}
+          />
+        </div>
+
+        <select
+          value={filters.company}
+          onChange={(e) =>
+            onFilterChange({ ...filters, company: e.target.value })
+          }
+          aria-label="Filter by company"
+          className={`${inputClass} w-full`}
+        >
+          <option value="">All companies</option>
+          {companyOptions.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={filters.jobTitle}
+          onChange={(e) =>
+            onFilterChange({ ...filters, jobTitle: e.target.value })
+          }
+          aria-label="Filter by job title"
+          className={`${inputClass} w-full`}
+        >
+          <option value="">All job titles</option>
+          {jobTitleOptions.map((j) => (
+            <option key={j} value={j}>
+              {j}
+            </option>
+          ))}
+        </select>
+
+        {hasActiveFilters && (
+          <div className="flex items-center">
+            <Button size="sm" onClick={handleClear} type="button">
+              Clear Filters
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-3 items-end">
+        <label className="flex flex-col text-sm text-gray-700 dark:text-gray-300">
+          <span className="mb-1">From</span>
+          <input
+            type="month"
+            value={filters.monthFrom}
+            onChange={(e) =>
+              onFilterChange({ ...filters, monthFrom: e.target.value })
+            }
+            aria-label="From month"
+            className={inputClass}
+          />
+        </label>
+        <label className="flex flex-col text-sm text-gray-700 dark:text-gray-300">
+          <span className="mb-1">To</span>
+          <input
+            type="month"
+            value={filters.monthTo}
+            onChange={(e) =>
+              onFilterChange({ ...filters, monthTo: e.target.value })
+            }
+            aria-label="To month"
+            className={inputClass}
+          />
+        </label>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/RecruiterTable.jsx
+++ b/src/components/sections/RecruiterTable.jsx
@@ -1,0 +1,237 @@
+import { useMemo, useState } from "react";
+import { ArrowUpDown, ArrowUp, ArrowDown, Inbox } from "lucide-react";
+import { Card, CardContent } from "../ui/card";
+
+const COLUMNS = [
+  { key: "company", label: "Company" },
+  { key: "jobTitle", label: "Job Title" },
+  { key: "recruiterLabel", label: "Recruiter" },
+  { key: "month", label: "Month" },
+];
+
+const pageBtnBase = "px-3 py-1 text-sm rounded-md";
+const pageBtnIdle = `${pageBtnBase} border border-gray-300 dark:border-gray-700 bg-white text-gray-700 dark:bg-gray-800 dark:text-gray-300`;
+
+function SortIcon({ active, direction }) {
+  if (!active) {
+    return <ArrowUpDown className="w-4 h-4" aria-hidden="true" />;
+  }
+  return direction === "asc" ? (
+    <ArrowUp className="w-4 h-4" aria-hidden="true" />
+  ) : (
+    <ArrowDown className="w-4 h-4" aria-hidden="true" />
+  );
+}
+
+function getPageNumbers(page, totalPages) {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  const candidates = [1, page - 1, page, page + 1, totalPages].filter(
+    (n) => n >= 1 && n <= totalPages
+  );
+  const unique = Array.from(new Set(candidates)).sort((a, b) => a - b);
+  const result = [];
+  for (let i = 0; i < unique.length; i++) {
+    if (i > 0 && unique[i] - unique[i - 1] > 1) {
+      result.push("…");
+    }
+    result.push(unique[i]);
+  }
+  return result;
+}
+
+export default function RecruiterTable({
+  data = [],
+  page,
+  pageSize = 10,
+  onPageChange,
+}) {
+  const [sort, setSort] = useState({ key: "month", direction: "desc" });
+
+  const sortedData = useMemo(() => {
+    const copy = [...data];
+    copy.sort((a, b) => {
+      const av = a[sort.key];
+      const bv = b[sort.key];
+      const aEmpty = av === undefined || av === null || av === "";
+      const bEmpty = bv === undefined || bv === null || bv === "";
+      if (aEmpty && bEmpty) return 0;
+      if (aEmpty) return 1;
+      if (bEmpty) return -1;
+      const cmp =
+        typeof av === "number" && typeof bv === "number"
+          ? av - bv
+          : String(av).localeCompare(String(bv), undefined, {
+              sensitivity: "base",
+            });
+      return sort.direction === "asc" ? cmp : -cmp;
+    });
+    return copy;
+  }, [data, sort]);
+
+  const totalPages = Math.max(1, Math.ceil(sortedData.length / pageSize));
+  const currentPage = Math.max(1, Math.min(page, totalPages));
+  const startIdx = (currentPage - 1) * pageSize;
+  const endIdx = Math.min(currentPage * pageSize, sortedData.length);
+  const pageRows = sortedData.slice(startIdx, endIdx);
+
+  function handleSort(key) {
+    setSort((prev) => {
+      if (prev.key !== key) {
+        return { key, direction: "asc" };
+      }
+      return { key, direction: prev.direction === "asc" ? "desc" : "asc" };
+    });
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <Inbox className="w-12 h-12 mx-auto text-gray-400 dark:text-gray-600" />
+        <p className="mt-4 text-gray-600 dark:text-gray-400">
+          No recruiter requests match your filters
+        </p>
+      </div>
+    );
+  }
+
+  const pageNumbers = getPageNumbers(currentPage, totalPages);
+
+  return (
+    <div>
+      {/* Desktop table */}
+      <div className="hidden md:block overflow-x-auto">
+        <table className="min-w-full">
+          <thead className="bg-gray-50 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-left text-sm font-medium uppercase tracking-wider">
+            <tr>
+              {COLUMNS.map((col) => {
+                const active = sort.key === col.key;
+                return (
+                  <th
+                    key={col.key}
+                    scope="col"
+                    aria-sort={
+                      active
+                        ? sort.direction === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : "none"
+                    }
+                    className="p-0"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => handleSort(col.key)}
+                      className="flex w-full items-center gap-2 px-4 py-3 text-left cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 select-none"
+                    >
+                      {col.label}
+                      <SortIcon active={active} direction={sort.direction} />
+                    </button>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {pageRows.map((r) => (
+              <tr
+                key={r.id}
+                className="border-b border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+                  {r.company || "—"}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+                  {r.jobTitle || "—"}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+                  {r.recruiterLabel || "Anonymous"}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+                  {r.month || "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile cards */}
+      <div className="md:hidden space-y-3">
+        {pageRows.map((r) => (
+          <Card key={r.id}>
+            <CardContent>
+              <div className="text-lg font-bold text-gray-900 dark:text-gray-100">
+                {r.company || "—"}
+              </div>
+              <div className="text-sm text-gray-600 dark:text-gray-400">
+                {r.jobTitle || "—"}
+              </div>
+              <div className="mt-2 text-sm text-gray-700 dark:text-gray-300">
+                {r.recruiterLabel || "Anonymous"}
+              </div>
+              <div className="mt-1 text-xs text-gray-500 dark:text-gray-400 text-right">
+                {r.month || "—"}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-between flex-wrap gap-3">
+          <div className="text-sm text-gray-600 dark:text-gray-400">
+            Showing {startIdx + 1}-{endIdx} of {sortedData.length}
+          </div>
+          <div className="flex items-center gap-1 flex-wrap">
+            <button
+              type="button"
+              onClick={() => onPageChange(currentPage - 1)}
+              disabled={currentPage === 1}
+              className={`${pageBtnIdle} ${
+                currentPage === 1 ? "opacity-50 cursor-not-allowed" : ""
+              }`}
+            >
+              Previous
+            </button>
+            {pageNumbers.map((n, i) =>
+              n === "…" ? (
+                <span
+                  key={`ellipsis-${i}`}
+                  className="px-2 text-sm text-gray-500 dark:text-gray-400"
+                >
+                  …
+                </span>
+              ) : (
+                <button
+                  key={n}
+                  type="button"
+                  onClick={() => onPageChange(n)}
+                  className={
+                    n === currentPage
+                      ? `${pageBtnBase} bg-blue-600 text-white`
+                      : pageBtnIdle
+                  }
+                >
+                  {n}
+                </button>
+              )
+            )}
+            <button
+              type="button"
+              onClick={() => onPageChange(currentPage + 1)}
+              disabled={currentPage === totalPages}
+              className={`${pageBtnIdle} ${
+                currentPage === totalPages ? "opacity-50 cursor-not-allowed" : ""
+              }`}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sections/RecruiterTable.jsx
+++ b/src/components/sections/RecruiterTable.jsx
@@ -209,6 +209,8 @@ export default function RecruiterTable({
                   key={n}
                   type="button"
                   onClick={() => onPageChange(n)}
+                  aria-label={`Go to page ${n}`}
+                  aria-current={n === currentPage ? "page" : undefined}
                   className={
                     n === currentPage
                       ? `${pageBtnBase} bg-blue-600 text-white`

--- a/src/components/sections/StatsCards.jsx
+++ b/src/components/sections/StatsCards.jsx
@@ -1,0 +1,84 @@
+import { Mail, Building2, Briefcase, CalendarDays } from "lucide-react";
+import { Card, CardContent } from "../ui/card";
+
+function pickTopJobTitle(topJobTitles) {
+  let top = null;
+  let topCount = 0;
+  for (const [title, count] of Object.entries(topJobTitles)) {
+    if (count > topCount) {
+      top = title;
+      topCount = count;
+    }
+  }
+  return top ?? "N/A";
+}
+
+export default function StatsCards({ stats }) {
+  const s = stats ?? {};
+  const byMonth = s.byMonth ?? {};
+  const topJobTitles = s.topJobTitles ?? {};
+
+  // UTC key — matches the server's byMonth keys (derived from date_day[:7]).
+  const currentMonth = new Date().toISOString().slice(0, 7);
+
+  const totalRequests = s.totalEmails ?? 0;
+  const uniqueCompanies = s.uniqueCompanies ?? 0;
+  const topJobTitle = pickTopJobTitle(topJobTitles);
+  const thisMonthCount = byMonth[currentMonth] ?? 0;
+
+  const cards = [
+    {
+      label: "Total Requests",
+      value: totalRequests,
+      icon: <Mail className="w-5 h-5 text-blue-600 dark:text-blue-300" />,
+      iconBg: "bg-blue-100 dark:bg-blue-900/40",
+    },
+    {
+      label: "Unique Companies",
+      value: uniqueCompanies,
+      icon: <Building2 className="w-5 h-5 text-green-600 dark:text-green-300" />,
+      iconBg: "bg-green-100 dark:bg-green-900/40",
+    },
+    {
+      label: "Top Job Title",
+      value: topJobTitle,
+      icon: <Briefcase className="w-5 h-5 text-purple-600 dark:text-purple-300" />,
+      iconBg: "bg-purple-100 dark:bg-purple-900/40",
+    },
+    {
+      label: "This Month",
+      value: thisMonthCount,
+      icon: <CalendarDays className="w-5 h-5 text-orange-600 dark:text-orange-300" />,
+      iconBg: "bg-orange-100 dark:bg-orange-900/40",
+    },
+  ];
+
+  return (
+    <section>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {cards.map(({ label, value, icon, iconBg }) => (
+          <Card key={label}>
+            <CardContent>
+              <div className="flex items-center gap-3">
+                <div className={`rounded-full p-2 ${iconBg}`}>
+                  {icon}
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    {label}
+                  </p>
+                  <p
+                    className="text-2xl font-bold text-gray-900 dark:text-white truncate"
+                    title={typeof value === "string" ? value : undefined}
+                  >
+                    {value}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/StatsCards.jsx
+++ b/src/components/sections/StatsCards.jsx
@@ -18,7 +18,12 @@ export default function StatsCards({ stats }) {
   const byMonth = s.byMonth ?? {};
   const topJobTitles = s.topJobTitles ?? {};
 
-  // UTC key — matches the server's byMonth keys (derived from date_day[:7]).
+  // Current month as a UTC "YYYY-MM" key. Note: the server's byMonth keys are
+  // derived from date_day[:7], which the email-parser formats from the email's
+  // Date header in its *original* timezone (not UTC). So for emails whose Date
+  // header straddles a month boundary relative to UTC, this lookup can under- or
+  // over-count "This Month". The robust fix is to format date_day in UTC server
+  // side; until then this is a known low-severity edge case.
   const currentMonth = new Date().toISOString().slice(0, 7);
 
   const totalRequests = s.totalEmails ?? 0;

--- a/src/lib/filters.js
+++ b/src/lib/filters.js
@@ -1,0 +1,10 @@
+// Shared empty/default state for the recruiter dashboard filters.
+// Imported by both DashboardPage (initial state / reset) and FilterBar
+// (default prop) so the filter shape has a single source of truth.
+export const EMPTY_FILTERS = {
+  search: "",
+  company: "",
+  jobTitle: "",
+  monthFrom: "",
+  monthTo: "",
+};

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AlertCircle, Loader2, RefreshCw } from "lucide-react";
+import { Button } from "../components/ui/button";
+import Breadcrumbs from "../components/layout/Breadcrumbs";
+import Header from "../components/layout/Header";
+import StatsCards from "../components/sections/StatsCards";
+import FilterBar from "../components/sections/FilterBar";
+import RecruiterTable from "../components/sections/RecruiterTable";
+import { EMPTY_FILTERS } from "../lib/filters";
+
+const RECRUITERS_URL = "https://api.sh3r4rd.com/recruiters";
+const STATS_URL = "https://api.sh3r4rd.com/stats";
+const PAGE_SIZE = 10;
+
+function matchesFilters(item, filters) {
+  const { search, company, jobTitle, monthFrom, monthTo } = filters;
+
+  if (company && item.company !== company) return false;
+  if (jobTitle && item.jobTitle !== jobTitle) return false;
+
+  if (search) {
+    const needle = search.toLowerCase();
+    const haystack = `${item.company ?? ""} ${item.jobTitle ?? ""}`.toLowerCase();
+    if (!haystack.includes(needle)) return false;
+  }
+
+  if (monthFrom && (item.month ?? "") < monthFrom) return false;
+  if (monthTo && (item.month ?? "") > monthTo) return false;
+
+  return true;
+}
+
+export default function DashboardPage() {
+  const [data, setData] = useState([]);
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [filters, setFilters] = useState(EMPTY_FILTERS);
+  const [page, setPage] = useState(1);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [recruitersRes, statsRes] = await Promise.all([
+        fetch(RECRUITERS_URL),
+        fetch(STATS_URL),
+      ]);
+      if (!recruitersRes.ok) {
+        throw new Error(`Request failed: ${recruitersRes.status}`);
+      }
+      const body = await recruitersRes.json();
+      setData(Array.isArray(body) ? body : []);
+      // Stats are supplementary; a stats failure shouldn't blank the table.
+      setStats(statsRes.ok ? await statsRes.json() : null);
+    } catch (err) {
+      setError(err.message || "Failed to load recruiter data");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const filteredData = useMemo(
+    () => data.filter((item) => matchesFilters(item, filters)),
+    [data, filters],
+  );
+
+  const handleFilterChange = useCallback((nextFilters) => {
+    setFilters(nextFilters);
+    setPage(1);
+  }, []);
+
+  const handleRefresh = () => {
+    setRefreshing(true);
+    loadData();
+  };
+
+  const filtersActive = useMemo(
+    () => Object.values(filters).some((v) => v !== ""),
+    [filters],
+  );
+
+  return (
+    <section className="max-w-4xl mx-auto space-y-12">
+      <Breadcrumbs />
+      <Header />
+
+      <section className="space-y-6">
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <h2 className="text-2xl font-semibold">Recruiter Dashboard</h2>
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={loading || refreshing}
+            className="inline-flex items-center gap-2 px-3 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <RefreshCw
+              className={`w-4 h-4 ${refreshing ? "animate-spin" : ""}`}
+            />
+            Refresh
+          </button>
+        </div>
+
+        {loading && !refreshing ? (
+          <div className="flex flex-col items-center justify-center py-16 text-gray-600 dark:text-gray-400">
+            <Loader2 className="w-8 h-8 animate-spin" />
+            <p className="mt-4">Loading recruiter data...</p>
+          </div>
+        ) : error ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <AlertCircle className="w-10 h-10 text-red-500 dark:text-red-400" />
+            <p className="mt-4 text-gray-700 dark:text-gray-300">{error}</p>
+            <div className="mt-4">
+              <Button onClick={loadData}>Try Again</Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <StatsCards stats={stats} />
+
+            <FilterBar
+              allData={data}
+              filters={filters}
+              onFilterChange={handleFilterChange}
+            />
+
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {filtersActive
+                ? `${filteredData.length} results (filtered from ${data.length})`
+                : `${data.length} results`}
+            </p>
+
+            <RecruiterTable
+              data={filteredData}
+              page={page}
+              pageSize={PAGE_SIZE}
+              onPageChange={setPage}
+            />
+          </>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -43,17 +43,19 @@ export default function DashboardPage() {
     setLoading(true);
     setError(null);
     try {
-      const [recruitersRes, statsRes] = await Promise.all([
-        fetch(RECRUITERS_URL),
-        fetch(STATS_URL),
-      ]);
+      // Stats are supplementary; isolate their failure so a stats network/CORS
+      // rejection (not just a non-ok status) can never blank the recruiter table.
+      const statsPromise = fetch(STATS_URL)
+        .then((res) => (res.ok ? res.json() : null))
+        .catch(() => null);
+
+      const recruitersRes = await fetch(RECRUITERS_URL);
       if (!recruitersRes.ok) {
         throw new Error(`Request failed: ${recruitersRes.status}`);
       }
       const body = await recruitersRes.json();
       setData(Array.isArray(body) ? body : []);
-      // Stats are supplementary; a stats failure shouldn't blank the table.
-      setStats(statsRes.ok ? await statsRes.json() : null);
+      setStats(await statsPromise);
     } catch (err) {
       setError(err.message || "Failed to load recruiter data");
     } finally {


### PR DESCRIPTION
## Summary

Phase 4 of the recruiter dashboard: the frontend that surfaces the anonymized data served by the `api-handler` Lambda. Adds a new `/dashboard` route assembling stats, filtering, and a sortable/paginated table.

This epic branch bundles four already-merged subtask PRs (#80, #81, #82, #83):

- **StatsCards** (`components/sections/StatsCards.jsx`) — four summary cards (Total Requests, Unique Companies, Top Job Title, This Month) driven by the `/stats` response.
- **FilterBar** (`components/sections/FilterBar.jsx`) — debounced search, company/job-title dropdowns derived from the unfiltered list, and a month range. Includes a Clear Filters action.
- **RecruiterTable** (`components/sections/RecruiterTable.jsx`) — sortable columns with empty-value sink-to-bottom ordering, client-side pagination with ellipsis page numbers, desktop table + mobile card layouts, and an empty state.
- **DashboardPage** (`pages/DashboardPage.jsx`) — fetches `/recruiters` and `/stats` in parallel, applies filters client-side, and handles loading/error/refresh states. A stats failure degrades gracefully without blanking the table.

Supporting changes:
- `lib/filters.js` — single source of truth for the empty filter shape, shared by the page and FilterBar.
- `App.jsx` — registers the `/dashboard` route.
- `eslint.config.js` / `.gitignore` — ignore `.claude/` and agent worktrees.

## Verification

- Field names align with the backend: `id`, `company`, `jobTitle`, `month`, `recruiterLabel`, `confidence` (anonymizer) and `totalEmails`, `uniqueCompanies`, `byMonth`, `topJobTitles` (stats).
- `npm run lint` — clean
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
