### PR TITLE
test(e2e): add Playwright E2E tests for dashboard (40)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ scratch/
 
 # Terraform build artifacts
 .build/
+
+# Playwright E2E
+playwright-report/
+test-results/
+/e2e/.cache

--- a/e2e/dashboard.spec.js
+++ b/e2e/dashboard.spec.js
@@ -1,7 +1,10 @@
 import { test, expect } from "@playwright/test";
 
-const RECRUITERS_URL = "https://api.sh3r4rd.com/recruiters";
-const STATS_URL = "https://api.sh3r4rd.com/stats";
+// Glob route patterns (not exact URLs) so the mocks still intercept if a query
+// string is ever appended (e.g. /recruiters?company=…). An exact-string match
+// would miss that and let the request escape to the real API.
+const RECRUITERS_ROUTE = "**/recruiters*";
+const STATS_ROUTE = "**/stats*";
 
 /**
  * Deterministic fixture: 12 recruiters spanning 3 companies, several job titles,
@@ -27,7 +30,9 @@ const STATS = {
   totalEmails: 12,
   uniqueCompanies: 3,
   byMonth: { "2025-01": 4, "2025-02": 4, "2025-03": 4 },
-  topJobTitles: { "Frontend Engineer": 3, "Backend Engineer": 3, "DevOps Engineer": 2 },
+  // Frontend Engineer is a unique max (3) so the "Top Job Title" assertion is
+  // unambiguous — it does not rely on object key order to break a tie.
+  topJobTitles: { "Frontend Engineer": 3, "Backend Engineer": 2, "DevOps Engineer": 2 },
 };
 
 /**
@@ -35,14 +40,14 @@ const STATS = {
  * called BEFORE page.goto so neither request escapes to the network.
  */
 async function mockApi(page, { recruiters = RECRUITERS, recruitersStatus = 200, stats = STATS } = {}) {
-  await page.route(RECRUITERS_URL, (route) =>
+  await page.route(RECRUITERS_ROUTE, (route) =>
     route.fulfill({
       status: recruitersStatus,
       contentType: "application/json",
       body: JSON.stringify(recruiters),
     }),
   );
-  await page.route(STATS_URL, (route) =>
+  await page.route(STATS_ROUTE, (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -56,6 +61,19 @@ function statValue(page, label) {
   return page
     .locator("p", { hasText: new RegExp(`^${label}$`) })
     .locator("xpath=following-sibling::p[1]");
+}
+
+/** Tailwind `md` breakpoint (px): at/above this the desktop table renders. */
+const MD_BREAKPOINT = 768;
+
+/**
+ * True when the viewport is at/above the md breakpoint. An unset viewport
+ * (full-size window) counts as desktop — this guards against viewportSize()
+ * returning null, mirroring the `!viewport ||` defense the Mobile suite uses.
+ */
+function isDesktop(page) {
+  const vp = page.viewportSize();
+  return !vp || vp.width >= MD_BREAKPOINT;
 }
 
 test.describe("Recruiter Dashboard", () => {
@@ -100,7 +118,7 @@ test.describe("Recruiter Dashboard", () => {
     ).toBeVisible();
     // Row-level cell assertion is desktop-only: the <table> is display:none
     // below the md breakpoint, so its cells leave the accessibility tree.
-    if (page.viewportSize().width >= 768) {
+    if (isDesktop(page)) {
       await expect(
         page.getByRole("cell", { name: "Data Scientist" }),
       ).toHaveCount(2);
@@ -119,7 +137,7 @@ test.describe("Recruiter Dashboard", () => {
       page.getByText("4 results (filtered from 12)"),
     ).toBeVisible();
     // Desktop-only: see note in the search-filter test.
-    if (page.viewportSize().width >= 768) {
+    if (isDesktop(page)) {
       await expect(page.getByRole("cell", { name: "Initech" })).toHaveCount(4);
     }
   });
@@ -144,10 +162,7 @@ test.describe("Recruiter Dashboard", () => {
   test("sort by column and toggle direction", async ({ page }) => {
     // Sortable column headers exist only in the desktop table; the mobile card
     // layout has no sortable headers, so this journey is desktop-only.
-    test.skip(
-      page.viewportSize().width < 768,
-      "sortable table headers are desktop-only",
-    );
+    test.skip(!isDesktop(page), "sortable table headers are desktop-only");
     await mockApi(page);
     await page.goto("/dashboard");
     await expect(page.getByText("12 results", { exact: true })).toBeVisible();

--- a/e2e/dashboard.spec.js
+++ b/e2e/dashboard.spec.js
@@ -1,0 +1,228 @@
+import { test, expect } from "@playwright/test";
+
+const RECRUITERS_URL = "https://api.sh3r4rd.com/recruiters";
+const STATS_URL = "https://api.sh3r4rd.com/stats";
+
+/**
+ * Deterministic fixture: 12 recruiters spanning 3 companies, several job titles,
+ * and 3 months. >10 rows exercises pagination (PAGE_SIZE = 10). Months are fixed
+ * (never "current") so the data is stable regardless of when the suite runs.
+ */
+const RECRUITERS = [
+  { id: "1", company: "Acme Corp", jobTitle: "Frontend Engineer", month: "2025-01", recruiterLabel: "Alice", confidence: 0.9 },
+  { id: "2", company: "Acme Corp", jobTitle: "Backend Engineer", month: "2025-01", recruiterLabel: "Bob", confidence: 0.8 },
+  { id: "3", company: "Acme Corp", jobTitle: "DevOps Engineer", month: "2025-02", recruiterLabel: "Carol", confidence: 0.7 },
+  { id: "4", company: "Globex", jobTitle: "Frontend Engineer", month: "2025-02", recruiterLabel: "Dave", confidence: 0.95 },
+  { id: "5", company: "Globex", jobTitle: "Data Scientist", month: "2025-02", recruiterLabel: "Eve", confidence: 0.6 },
+  { id: "6", company: "Globex", jobTitle: "Product Manager", month: "2025-03", recruiterLabel: "Frank", confidence: 0.5 },
+  { id: "7", company: "Initech", jobTitle: "Backend Engineer", month: "2025-03", recruiterLabel: "Grace", confidence: 0.85 },
+  { id: "8", company: "Initech", jobTitle: "Frontend Engineer", month: "2025-03", recruiterLabel: "Heidi", confidence: 0.75 },
+  { id: "9", company: "Initech", jobTitle: "DevOps Engineer", month: "2025-01", recruiterLabel: "Ivan", confidence: 0.65 },
+  { id: "10", company: "Initech", jobTitle: "Data Scientist", month: "2025-02", recruiterLabel: "Judy", confidence: 0.55 },
+  { id: "11", company: "Acme Corp", jobTitle: "Product Manager", month: "2025-03", recruiterLabel: "Mallory", confidence: 0.45 },
+  { id: "12", company: "Globex", jobTitle: "Backend Engineer", month: "2025-01", recruiterLabel: "Niaj", confidence: 0.35 },
+];
+
+const STATS = {
+  totalEmails: 12,
+  uniqueCompanies: 3,
+  byMonth: { "2025-01": 4, "2025-02": 4, "2025-03": 4 },
+  topJobTitles: { "Frontend Engineer": 3, "Backend Engineer": 3, "DevOps Engineer": 2 },
+};
+
+/**
+ * Register API mocks for BOTH endpoints the dashboard fetches on load. Must be
+ * called BEFORE page.goto so neither request escapes to the network.
+ */
+async function mockApi(page, { recruiters = RECRUITERS, recruitersStatus = 200, stats = STATS } = {}) {
+  await page.route(RECRUITERS_URL, (route) =>
+    route.fulfill({
+      status: recruitersStatus,
+      contentType: "application/json",
+      body: JSON.stringify(recruiters),
+    }),
+  );
+  await page.route(STATS_URL, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(stats),
+    }),
+  );
+}
+
+/** Locate a stats card by its label and return the locator for its value <p>. */
+function statValue(page, label) {
+  return page
+    .locator("p", { hasText: new RegExp(`^${label}$`) })
+    .locator("xpath=following-sibling::p[1]");
+}
+
+test.describe("Recruiter Dashboard", () => {
+  test("loads and renders heading with table rows", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/dashboard");
+
+    await expect(
+      page.getByRole("heading", { name: "Recruiter Dashboard" }),
+    ).toBeVisible();
+
+    // Results count line reflects the full dataset (no filter).
+    await expect(page.getByText("12 results", { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Refresh" })).toBeVisible();
+
+    // First page shows PAGE_SIZE (10) rows; pagination summary confirms total.
+    await expect(page.getByText("Showing 1-10 of 12")).toBeVisible();
+  });
+
+  test("stats cards show totals", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/dashboard");
+
+    await expect(statValue(page, "Total Requests")).toHaveText("12");
+    await expect(statValue(page, "Unique Companies")).toHaveText("3");
+    // Top job title is the max-count entry in topJobTitles.
+    await expect(statValue(page, "Top Job Title")).toHaveText("Frontend Engineer");
+  });
+
+  test("search filter narrows results", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/dashboard");
+    await expect(page.getByText("12 results", { exact: true })).toBeVisible();
+
+    // "data scientist" matches company+jobTitle substring; 2 rows (Globex, Initech).
+    await page
+      .getByLabel("Search company or job title")
+      .fill("data scientist");
+
+    await expect(
+      page.getByText("2 results (filtered from 12)"),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("cell", { name: "Data Scientist" }),
+    ).toHaveCount(2);
+  });
+
+  test("company filter narrows results", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/dashboard");
+    await expect(page.getByText("12 results", { exact: true })).toBeVisible();
+
+    // Initech has 4 recruiters.
+    await page.getByLabel("Filter by company").selectOption("Initech");
+
+    await expect(
+      page.getByText("4 results (filtered from 12)"),
+    ).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Initech" })).toHaveCount(4);
+  });
+
+  test("clear filters restores full dataset", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/dashboard");
+
+    await page.getByLabel("Filter by company").selectOption("Globex");
+    await expect(
+      page.getByText("4 results (filtered from 12)"),
+    ).toBeVisible();
+
+    const clear = page.getByRole("button", { name: "Clear Filters" });
+    await expect(clear).toBeVisible();
+    await clear.click();
+
+    await expect(page.getByText("12 results", { exact: true })).toBeVisible();
+    await expect(clear).toBeHidden();
+  });
+
+  test("sort by column and toggle direction", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/dashboard");
+    await expect(page.getByText("12 results", { exact: true })).toBeVisible();
+
+    const companyHeader = page.getByRole("columnheader", { name: "Company" });
+    const companyHeaderBtn = companyHeader.getByRole("button", {
+      name: "Company",
+    });
+
+    // Default sort is month descending; Company starts unsorted.
+    await expect(companyHeader).toHaveAttribute("aria-sort", "none");
+
+    // First click -> ascending.
+    await companyHeaderBtn.click();
+    await expect(companyHeader).toHaveAttribute("aria-sort", "ascending");
+    // Ascending: first company alphabetically is "Acme Corp".
+    await expect(
+      page.locator("tbody tr").first().locator("td").first(),
+    ).toHaveText("Acme Corp");
+
+    // Second click toggles -> descending.
+    await companyHeaderBtn.click();
+    await expect(companyHeader).toHaveAttribute("aria-sort", "descending");
+    // Descending: first company is "Initech".
+    await expect(
+      page.locator("tbody tr").first().locator("td").first(),
+    ).toHaveText("Initech");
+  });
+
+  test("empty state when API returns no recruiters", async ({ page }) => {
+    await mockApi(page, { recruiters: [] });
+    await page.goto("/dashboard");
+
+    await expect(
+      page.getByText("No recruiter requests match your filters"),
+    ).toBeVisible();
+    await expect(page.getByText("0 results", { exact: true })).toBeVisible();
+  });
+
+  test("error state when recruiters API returns 500", async ({ page }) => {
+    await mockApi(page, { recruitersStatus: 500 });
+    await page.goto("/dashboard");
+
+    await expect(page.getByText("Request failed: 500")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Try Again" }),
+    ).toBeVisible();
+    // Table should not render in the error state.
+    await expect(page.locator("table")).toHaveCount(0);
+  });
+});
+
+test.describe("Mobile layout", () => {
+  // Only meaningful at the mobile viewport (< 768px md breakpoint).
+  test.skip(
+    ({ viewport }) => !viewport || viewport.width >= 768,
+    "mobile-only assertions",
+  );
+
+  test("renders card layout instead of table at 375px", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/dashboard");
+    await expect(page.getByText("12 results", { exact: true })).toBeVisible();
+
+    // The desktop <table> is hidden below the md breakpoint.
+    await expect(page.locator("table")).toBeHidden();
+
+    // Card content (a company name) is visible instead.
+    await expect(
+      page.getByText("Acme Corp", { exact: true }).first(),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Dark mode", () => {
+  test.use({ colorScheme: "dark" });
+
+  test("uses dark background", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Recruiter Dashboard" }),
+    ).toBeVisible();
+
+    // <main> root: bg-white / dark:bg-gray-900 (rgb(17, 24, 39)).
+    await expect(page.locator("main")).toHaveCSS(
+      "background-color",
+      "rgb(17, 24, 39)",
+    );
+  });
+});

--- a/e2e/dashboard.spec.js
+++ b/e2e/dashboard.spec.js
@@ -98,9 +98,13 @@ test.describe("Recruiter Dashboard", () => {
     await expect(
       page.getByText("2 results (filtered from 12)"),
     ).toBeVisible();
-    await expect(
-      page.getByRole("cell", { name: "Data Scientist" }),
-    ).toHaveCount(2);
+    // Row-level cell assertion is desktop-only: the <table> is display:none
+    // below the md breakpoint, so its cells leave the accessibility tree.
+    if (page.viewportSize().width >= 768) {
+      await expect(
+        page.getByRole("cell", { name: "Data Scientist" }),
+      ).toHaveCount(2);
+    }
   });
 
   test("company filter narrows results", async ({ page }) => {
@@ -114,7 +118,10 @@ test.describe("Recruiter Dashboard", () => {
     await expect(
       page.getByText("4 results (filtered from 12)"),
     ).toBeVisible();
-    await expect(page.getByRole("cell", { name: "Initech" })).toHaveCount(4);
+    // Desktop-only: see note in the search-filter test.
+    if (page.viewportSize().width >= 768) {
+      await expect(page.getByRole("cell", { name: "Initech" })).toHaveCount(4);
+    }
   });
 
   test("clear filters restores full dataset", async ({ page }) => {
@@ -135,6 +142,12 @@ test.describe("Recruiter Dashboard", () => {
   });
 
   test("sort by column and toggle direction", async ({ page }) => {
+    // Sortable column headers exist only in the desktop table; the mobile card
+    // layout has no sortable headers, so this journey is desktop-only.
+    test.skip(
+      page.viewportSize().width < 768,
+      "sortable table headers are desktop-only",
+    );
     await mockApi(page);
     await page.goto("/dashboard");
     await expect(page.getByText("12 results", { exact: true })).toBeVisible();
@@ -202,9 +215,14 @@ test.describe("Mobile layout", () => {
     // The desktop <table> is hidden below the md breakpoint.
     await expect(page.locator("table")).toBeHidden();
 
-    // Card content (a company name) is visible instead.
+    // Card content (a company name) is visible instead. Filter to visible
+    // matches so we don't latch onto the hidden <option> in the company
+    // dropdown, which also contains the text "Acme Corp".
     await expect(
-      page.getByText("Acme Corp", { exact: true }).first(),
+      page
+        .getByText("Acme Corp", { exact: true })
+        .filter({ visible: true })
+        .first(),
     ).toBeVisible();
   });
 });

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright configuration for the recruiter dashboard E2E suite.
+ *
+ * This config lives in `e2e/` (not the repo root), so paths that Playwright
+ * resolves relative to the config directory are set accordingly:
+ *   - `testDir: '.'` -> the e2e/ folder itself.
+ *   - `webServer.cwd: '..'` -> the repo root, where `npm run dev` (Vite) lives.
+ *
+ * Invoke via the package scripts, which pass `--config e2e/playwright.config.js`.
+ */
+export default defineConfig({
+  testDir: ".",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [["html", { outputFolder: "../playwright-report", open: "never" }]],
+  outputDir: "../test-results",
+
+  use: {
+    baseURL: "http://localhost:5173",
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "desktop-chrome",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+    {
+      name: "mobile-chrome",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 375, height: 667 },
+        isMobile: true,
+        hasTouch: true,
+      },
+    },
+  ],
+
+  webServer: {
+    command: "npm run dev",
+    cwd: "..",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,4 +26,16 @@ export default defineConfig([
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
+  {
+    // Playwright E2E tests run under Node, not the browser. Give them Node
+    // globals (e.g. `process`) and disable the react-refresh component-export
+    // rule, which is irrelevant to test modules.
+    files: ['e2e/**/*.js'],
+    languageOptions: {
+      globals: globals.node,
+    },
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
+        "@playwright/test": "^1.52.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@types/react": "^19.1.8",
@@ -1282,6 +1283,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -8145,6 +8162,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test --config e2e/playwright.config.js",
+    "test:e2e:ui": "playwright test --config e2e/playwright.config.js --ui"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.16",
@@ -18,6 +20,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@playwright/test": "^1.52.0",
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/git": "^10.0.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
@@ -27,10 +32,8 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
-    "tailwindcss": "^3.4.1",
     "semantic-release": "^24.0.0",
-    "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/git": "^10.0.1",
+    "tailwindcss": "^3.4.1",
     "vite": "^7.0.4"
   }
 }


### PR DESCRIPTION
Closes #40

## Summary
Adds a Playwright E2E test suite for the recruiter dashboard (`/dashboard`). The config lives in `e2e/` and auto-starts the Vite dev server. Both API endpoints the page fetches (`/recruiters` and `/stats`) are mocked with `page.route()` before navigation so tests are deterministic. A self-contained 12-row fixture (3 companies, several job titles, 3 fixed months) exercises pagination, sorting, and filtering.

## Files
- `e2e/playwright.config.js` — `testDir: '.'`, `baseURL: http://localhost:5173`, `webServer` runs `npm run dev` with `cwd: '..'`, `reuseExistingServer: !CI`, `retries: CI ? 2 : 0`, `screenshot: only-on-failure`, `trace: on-first-retry`, HTML reporter to `../playwright-report`. Two projects: `desktop-chrome` (1280x720) and `mobile-chrome` (375x667, Chromium).
- `e2e/dashboard.spec.js` — the test suite (see cases below).
- `package.json` — `@playwright/test` devDependency (`^1.52.0`); scripts `test:e2e` and `test:e2e:ui`.
- `package-lock.json` — lockfile updated.
- `.gitignore` — ignores `playwright-report/`, `test-results/`, `/e2e/.cache`.
- `eslint.config.js` — `e2e/**` override granting Node globals and disabling `react-refresh/only-export-components`.

## Test cases covered
1. Dashboard loads (heading + rows + results count + pagination summary)
2. Stats cards totals (Total Requests, Unique Companies, Top Job Title)
3. Search filter (substring of company + jobTitle)
4. Company filter (`<select>` selectOption)
5. Clear filters restores full dataset
6. Sort by column + toggle direction (asserts `aria-sort` and row order)
7. Empty state (API returns `[]`)
8. Error state (API 500 -> error text + Try Again, no table)
9. Mobile responsive card layout at 375px (table hidden, card content visible; mobile-chrome only)
10. Dark mode (`<main>` background = `rgb(17, 24, 39)` via `colorScheme: 'dark'`)

## Deviations from the issue spec
- **`--config` flag:** Because the config lives in `e2e/` (not repo root), the scripts use `playwright test --config e2e/playwright.config.js` instead of the issue's bare `playwright test`.
- **eslint override:** Added a targeted `e2e/**` config block (Node globals + disabled `react-refresh/only-export-components`) rather than disabling rules globally.
- **`@playwright/test` version:** Declared `^1.52.0` as specified; npm resolved the lockfile to the latest compatible `1.60.0` (caret-satisfying).

## Verification
- `npm run lint` passes (e2e files included).
- `node --check` passes on both `e2e/*.js` files.
- **Could NOT run `npm run test:e2e` / `npx playwright install chromium` in the agent environment** — every Playwright/npx invocation and the browser download were denied by the sandbox permission layer, and no Chromium build is cached. The suite has not been executed here. Please run `npx playwright install chromium && npm run test:e2e` locally / in CI to confirm green on both projects. Tests use web-first assertions and routes set up before navigation, so they should be robust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)