### PR TITLE
test(frontend): add component and integration tests for dashboard (39)

### DIFF
--- a/src/components/sections/__tests__/FilterBar.test.jsx
+++ b/src/components/sections/__tests__/FilterBar.test.jsx
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import FilterBar from '../FilterBar'
+import { EMPTY_FILTERS } from '../../../lib/filters'
+
+const SAMPLE = [
+  { id: '1', company: 'Globex', jobTitle: 'Software Engineer', month: '2026-05' },
+  { id: '2', company: 'Acme Corp', jobTitle: 'Engineering Manager', month: '2026-04' },
+  { id: '3', company: 'Acme Corp', jobTitle: 'Software Engineer', month: '2026-03' },
+]
+
+function renderBar(filters = EMPTY_FILTERS, onFilterChange = vi.fn()) {
+  render(
+    <FilterBar allData={SAMPLE} filters={filters} onFilterChange={onFilterChange} />,
+  )
+  return { onFilterChange }
+}
+
+describe('FilterBar', () => {
+  it('renders search input and the two dropdowns', () => {
+    renderBar()
+    expect(screen.getByLabelText('Search company or job title')).toBeInTheDocument()
+    expect(screen.getByLabelText('Filter by company')).toBeInTheDocument()
+    expect(screen.getByLabelText('Filter by job title')).toBeInTheDocument()
+  })
+
+  it('derives sorted, de-duplicated company options from allData', () => {
+    renderBar()
+    const select = screen.getByLabelText('Filter by company')
+    const options = [...select.querySelectorAll('option')].map((o) => o.textContent)
+    expect(options).toEqual(['All companies', 'Acme Corp', 'Globex'])
+  })
+
+  it('derives sorted, de-duplicated job title options from allData', () => {
+    renderBar()
+    const select = screen.getByLabelText('Filter by job title')
+    const options = [...select.querySelectorAll('option')].map((o) => o.textContent)
+    expect(options).toEqual(['All job titles', 'Engineering Manager', 'Software Engineer'])
+  })
+
+  it('pushes a debounced search change up to the parent', async () => {
+    const user = userEvent.setup()
+    const { onFilterChange } = renderBar()
+    await user.type(screen.getByLabelText('Search company or job title'), 'eng')
+    await waitFor(() =>
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({ search: 'eng' }),
+      ),
+    )
+  })
+
+  it('emits a company filter change immediately on select', async () => {
+    const user = userEvent.setup()
+    const { onFilterChange } = renderBar()
+    await user.selectOptions(screen.getByLabelText('Filter by company'), 'Globex')
+    expect(onFilterChange).toHaveBeenCalledWith(
+      expect.objectContaining({ company: 'Globex' }),
+    )
+  })
+
+  it('emits a job title filter change immediately on select', async () => {
+    const user = userEvent.setup()
+    const { onFilterChange } = renderBar()
+    await user.selectOptions(
+      screen.getByLabelText('Filter by job title'),
+      'Software Engineer',
+    )
+    expect(onFilterChange).toHaveBeenCalledWith(
+      expect.objectContaining({ jobTitle: 'Software Engineer' }),
+    )
+  })
+
+  it('emits month range changes', async () => {
+    const user = userEvent.setup()
+    const { onFilterChange } = renderBar()
+    await user.type(screen.getByLabelText('From month'), '2026-01')
+    expect(onFilterChange).toHaveBeenCalledWith(
+      expect.objectContaining({ monthFrom: '2026-01' }),
+    )
+  })
+
+  it('hides the Clear Filters button when no filters are active', () => {
+    renderBar()
+    expect(screen.queryByRole('button', { name: 'Clear Filters' })).toBeNull()
+  })
+
+  it('shows Clear Filters when a filter is active and resets on click', async () => {
+    const user = userEvent.setup()
+    const onFilterChange = vi.fn()
+    render(
+      <FilterBar
+        allData={SAMPLE}
+        filters={{ ...EMPTY_FILTERS, company: 'Globex' }}
+        onFilterChange={onFilterChange}
+      />,
+    )
+    const clear = screen.getByRole('button', { name: 'Clear Filters' })
+    await user.click(clear)
+    expect(onFilterChange).toHaveBeenCalledWith(EMPTY_FILTERS)
+  })
+
+  it('tolerates a missing/empty allData list', () => {
+    render(<FilterBar allData={undefined} onFilterChange={vi.fn()} />)
+    // Only the placeholder options exist.
+    expect(
+      [...screen.getByLabelText('Filter by company').querySelectorAll('option')].length,
+    ).toBe(1)
+  })
+})

--- a/src/components/sections/__tests__/RecruiterTable.test.jsx
+++ b/src/components/sections/__tests__/RecruiterTable.test.jsx
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import RecruiterTable from '../RecruiterTable'
+
+function makeRows(n) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `r${i + 1}`,
+    company: `Company ${String(i + 1).padStart(2, '0')}`,
+    jobTitle: 'Software Engineer',
+    recruiterLabel: `Recruiter at Company ${i + 1}`,
+    month: `2026-${String((i % 12) + 1).padStart(2, '0')}`,
+  }))
+}
+
+describe('RecruiterTable', () => {
+  it('shows the empty state when there is no data', () => {
+    render(<RecruiterTable data={[]} page={1} onPageChange={vi.fn()} />)
+    expect(
+      screen.getByText('No recruiter requests match your filters'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders a row per record in the desktop table', () => {
+    const data = makeRows(3)
+    render(<RecruiterTable data={data} page={1} onPageChange={vi.fn()} />)
+    const table = screen.getByRole('table')
+    const bodyRows = within(table).getAllByRole('row').slice(1) // drop header row
+    expect(bodyRows).toHaveLength(3)
+  })
+
+  it('falls back to "Anonymous" when recruiterLabel is missing', () => {
+    const data = [
+      { id: 'x', company: 'Acme', jobTitle: 'SE', recruiterLabel: '', month: '2026-05' },
+    ]
+    render(<RecruiterTable data={data} page={1} onPageChange={vi.fn()} />)
+    expect(screen.getAllByText('Anonymous').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('defaults to sorting by month descending', () => {
+    const data = [
+      { id: 'a', company: 'A', jobTitle: 'x', recruiterLabel: 'l', month: '2026-01' },
+      { id: 'b', company: 'B', jobTitle: 'x', recruiterLabel: 'l', month: '2026-12' },
+    ]
+    render(<RecruiterTable data={data} page={1} onPageChange={vi.fn()} />)
+    const monthHeader = screen.getByRole('columnheader', { name: /Month/ })
+    expect(monthHeader).toHaveAttribute('aria-sort', 'descending')
+    const table = screen.getByRole('table')
+    const firstRow = within(table).getAllByRole('row')[1]
+    expect(within(firstRow).getByText('2026-12')).toBeInTheDocument()
+  })
+
+  it('sorts ascending on first click of a new column and toggles on repeat', async () => {
+    const user = userEvent.setup()
+    const data = [
+      { id: 'a', company: 'Zeta', jobTitle: 'x', recruiterLabel: 'l', month: '2026-05' },
+      { id: 'b', company: 'Alpha', jobTitle: 'x', recruiterLabel: 'l', month: '2026-04' },
+    ]
+    render(<RecruiterTable data={data} page={1} onPageChange={vi.fn()} />)
+
+    const companyHeaderBtn = screen.getByRole('button', { name: /Company/ })
+    await user.click(companyHeaderBtn)
+
+    let companyHeader = screen.getByRole('columnheader', { name: /Company/ })
+    expect(companyHeader).toHaveAttribute('aria-sort', 'ascending')
+    let rows = within(screen.getByRole('table')).getAllByRole('row').slice(1)
+    expect(within(rows[0]).getByText('Alpha')).toBeInTheDocument()
+
+    // Click again → descending.
+    await user.click(companyHeaderBtn)
+    companyHeader = screen.getByRole('columnheader', { name: /Company/ })
+    expect(companyHeader).toHaveAttribute('aria-sort', 'descending')
+    rows = within(screen.getByRole('table')).getAllByRole('row').slice(1)
+    expect(within(rows[0]).getByText('Zeta')).toBeInTheDocument()
+  })
+
+  it('paginates: only pageSize rows render and page controls appear', () => {
+    const data = makeRows(25)
+    render(<RecruiterTable data={data} page={1} pageSize={10} onPageChange={vi.fn()} />)
+    const bodyRows = within(screen.getByRole('table')).getAllByRole('row').slice(1)
+    expect(bodyRows).toHaveLength(10)
+    expect(screen.getByText('Showing 1-10 of 25')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument()
+  })
+
+  it('calls onPageChange when a page control is clicked', async () => {
+    const user = userEvent.setup()
+    const onPageChange = vi.fn()
+    const data = makeRows(25)
+    render(<RecruiterTable data={data} page={1} pageSize={10} onPageChange={onPageChange} />)
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+    expect(onPageChange).toHaveBeenCalledWith(2)
+    await user.click(screen.getByRole('button', { name: 'Go to page 3' }))
+    expect(onPageChange).toHaveBeenCalledWith(3)
+  })
+
+  it('disables Previous on the first page', () => {
+    const data = makeRows(25)
+    render(<RecruiterTable data={data} page={1} pageSize={10} onPageChange={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled()
+  })
+
+  it('clamps an out-of-range page down to the last valid page', () => {
+    const data = makeRows(25)
+    // page 99 is past the end; component clamps to page 3 (rows 21-25).
+    render(<RecruiterTable data={data} page={99} pageSize={10} onPageChange={vi.fn()} />)
+    expect(screen.getByText('Showing 21-25 of 25')).toBeInTheDocument()
+  })
+})

--- a/src/components/sections/__tests__/StatsCards.test.jsx
+++ b/src/components/sections/__tests__/StatsCards.test.jsx
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import StatsCards from '../StatsCards'
+
+describe('StatsCards', () => {
+  it('renders all four card labels', () => {
+    render(<StatsCards stats={null} />)
+    expect(screen.getByText('Total Requests')).toBeInTheDocument()
+    expect(screen.getByText('Unique Companies')).toBeInTheDocument()
+    expect(screen.getByText('Top Job Title')).toBeInTheDocument()
+    expect(screen.getByText('This Month')).toBeInTheDocument()
+  })
+
+  it('falls back to zeros and N/A when stats is null', () => {
+    render(<StatsCards stats={null} />)
+    // Total Requests, Unique Companies, This Month all render 0.
+    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(3)
+    expect(screen.getByText('N/A')).toBeInTheDocument()
+  })
+
+  it('falls back to zeros and N/A when stats is undefined (no prop)', () => {
+    render(<StatsCards />)
+    expect(screen.getByText('N/A')).toBeInTheDocument()
+  })
+
+  it('renders totals and the most frequent job title from stats', () => {
+    const stats = {
+      totalEmails: 42,
+      uniqueCompanies: 7,
+      byMonth: {},
+      topJobTitles: {
+        'Software Engineer': 5,
+        'Engineering Manager': 9,
+        'Staff Engineer': 2,
+      },
+    }
+    render(<StatsCards stats={stats} />)
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('7')).toBeInTheDocument()
+    // Top job title is the one with the highest count.
+    expect(screen.getByText('Engineering Manager')).toBeInTheDocument()
+  })
+
+  describe('This Month (time-dependent)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      // Fixed instant so the UTC "YYYY-MM" key is deterministic.
+      vi.setSystemTime(new Date('2026-05-15T12:00:00Z'))
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('reads the current UTC month bucket from byMonth', () => {
+      const stats = {
+        totalEmails: 10,
+        uniqueCompanies: 3,
+        byMonth: { '2026-05': 4, '2026-04': 6 },
+        topJobTitles: { 'Software Engineer': 10 },
+      }
+      render(<StatsCards stats={stats} />)
+      // "This Month" → 2026-05 → 4
+      expect(screen.getByText('4')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/ui/__tests__/card.test.jsx
+++ b/src/components/ui/__tests__/card.test.jsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Card, CardContent } from '../card'
+
+describe('Card', () => {
+  it('renders its children', () => {
+    render(
+      <Card>
+        <span>card body</span>
+      </Card>,
+    )
+    expect(screen.getByText('card body')).toBeInTheDocument()
+  })
+})
+
+describe('CardContent', () => {
+  it('renders its children', () => {
+    render(<CardContent>inner</CardContent>)
+    expect(screen.getByText('inner')).toBeInTheDocument()
+  })
+
+  it('appends a custom className alongside the base padding', () => {
+    render(<CardContent className="custom-class">x</CardContent>)
+    const el = screen.getByText('x')
+    expect(el).toHaveClass('p-4')
+    expect(el).toHaveClass('custom-class')
+  })
+})

--- a/src/pages/__tests__/DashboardPage.test.jsx
+++ b/src/pages/__tests__/DashboardPage.test.jsx
@@ -6,7 +6,7 @@ import { http, HttpResponse } from 'msw'
 import DashboardPage from '../DashboardPage'
 import { server } from '../../mocks/server'
 import { API_BASE } from '../../mocks/handlers'
-import { RECRUITERS } from '../../mocks/fixtures'
+import { createRecruiter, RECRUITERS } from '../../mocks/fixtures'
 
 // DashboardPage renders Breadcrumbs (useLocation), so a router is required.
 function renderDashboard() {
@@ -38,12 +38,29 @@ describe('DashboardPage (integration)', () => {
     expect(screen.getByText(`${RECRUITERS.length} results`)).toBeInTheDocument()
   })
 
-  it('renders the correct stats totals from /stats', async () => {
+  it('renders stats totals sourced from /stats', async () => {
+    // Distinctive totals that do NOT match the /recruiters count (12) or any
+    // rendered page number, so a passing assertion proves the values come from
+    // the /stats response and not from the recruiter list.
+    server.use(
+      http.get(`${API_BASE}/stats`, () =>
+        HttpResponse.json({
+          totalEmails: 42,
+          uniqueCompanies: 7,
+          byMonth: {},
+          topJobTitles: {},
+        }),
+      ),
+    )
     renderDashboard()
-    expect(await screen.findByText('Total Requests')).toBeInTheDocument()
-    // totalEmails === 12 unique enough to assert directly.
-    expect(screen.getByText(String(RECRUITERS.length))).toBeInTheDocument()
-    expect(screen.getByText('Unique Companies')).toBeInTheDocument()
+
+    // Scope each assertion to its own stat card so a coincidental duplicate
+    // elsewhere on the page (e.g. a pagination button) can't satisfy the match.
+    const totalCard = (await screen.findByText('Total Requests')).closest('div')
+    expect(within(totalCard).getByText('42')).toBeInTheDocument()
+
+    const companiesCard = screen.getByText('Unique Companies').closest('div')
+    expect(within(companiesCard).getByText('7')).toBeInTheDocument()
   })
 
   it('shows an error state and recovers via Try Again', async () => {
@@ -126,12 +143,39 @@ describe('DashboardPage (integration)', () => {
     )
   })
 
-  it('refreshes data when Refresh is clicked', async () => {
+  it('refetches data when Refresh is clicked', async () => {
+    // Return the original dataset first, then a changed dataset on the refetch,
+    // so we can prove Refresh actually re-hits /recruiters and re-renders.
+    let calls = 0
+    server.use(
+      http.get(`${API_BASE}/recruiters`, () => {
+        calls += 1
+        if (calls === 1) return HttpResponse.json(RECRUITERS)
+        return HttpResponse.json([
+          createRecruiter({
+            id: 'rec-refreshed',
+            company: 'Refreshed Co',
+            jobTitle: 'Refreshed Role',
+            month: '2026-05',
+          }),
+        ])
+      }),
+    )
     const user = userEvent.setup()
     renderDashboard()
-    await screen.findByRole('table')
+
+    const table = await screen.findByRole('table')
+    // The refreshed company is absent from the initial dataset.
+    expect(within(table).queryByText('Refreshed Co')).toBeNull()
+
     await user.click(screen.getByRole('button', { name: /Refresh/ }))
-    // Table remains after a successful refresh.
-    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument())
+
+    // The changed dataset from the second fetch now renders: a single row whose
+    // company is scoped to the table (it also appears in the mobile-card view).
+    await waitFor(() => expect(tableBodyRows()).toHaveLength(1))
+    expect(
+      within(screen.getByRole('table')).getByText('Refreshed Co'),
+    ).toBeInTheDocument()
+    expect(calls).toBe(2)
   })
 })

--- a/src/pages/__tests__/DashboardPage.test.jsx
+++ b/src/pages/__tests__/DashboardPage.test.jsx
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import DashboardPage from '../DashboardPage'
+import { server } from '../../mocks/server'
+import { API_BASE } from '../../mocks/handlers'
+import { RECRUITERS } from '../../mocks/fixtures'
+
+// DashboardPage renders Breadcrumbs (useLocation), so a router is required.
+function renderDashboard() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard']}>
+      <DashboardPage />
+    </MemoryRouter>,
+  )
+}
+
+// Body rows of the desktop <table> (excludes the header row).
+function tableBodyRows() {
+  return within(screen.getByRole('table')).getAllByRole('row').slice(1)
+}
+
+describe('DashboardPage (integration)', () => {
+  it('shows a loading state before data arrives', () => {
+    renderDashboard()
+    expect(screen.getByText('Loading recruiter data...')).toBeInTheDocument()
+  })
+
+  it('renders recruiter data once the fetch resolves', async () => {
+    renderDashboard()
+    await waitFor(() =>
+      expect(screen.queryByText('Loading recruiter data...')).toBeNull(),
+    )
+    // 12 fixture rows, paginated to 10 per page.
+    expect(tableBodyRows()).toHaveLength(10)
+    expect(screen.getByText(`${RECRUITERS.length} results`)).toBeInTheDocument()
+  })
+
+  it('renders the correct stats totals from /stats', async () => {
+    renderDashboard()
+    expect(await screen.findByText('Total Requests')).toBeInTheDocument()
+    // totalEmails === 12 unique enough to assert directly.
+    expect(screen.getByText(String(RECRUITERS.length))).toBeInTheDocument()
+    expect(screen.getByText('Unique Companies')).toBeInTheDocument()
+  })
+
+  it('shows an error state and recovers via Try Again', async () => {
+    let attempt = 0
+    server.use(
+      http.get(`${API_BASE}/recruiters`, () => {
+        attempt += 1
+        if (attempt === 1) {
+          return new HttpResponse(null, { status: 500 })
+        }
+        return HttpResponse.json(RECRUITERS)
+      }),
+    )
+    const user = userEvent.setup()
+    renderDashboard()
+
+    expect(await screen.findByText(/Request failed: 500/)).toBeInTheDocument()
+    const tryAgain = screen.getByRole('button', { name: 'Try Again' })
+    await user.click(tryAgain)
+
+    // Second attempt succeeds → table renders.
+    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument())
+  })
+
+  it('handles an empty API response', async () => {
+    server.use(http.get(`${API_BASE}/recruiters`, () => HttpResponse.json([])))
+    renderDashboard()
+    expect(
+      await screen.findByText('No recruiter requests match your filters'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('0 results')).toBeInTheDocument()
+  })
+
+  it('filters recruiters when the user types in search', async () => {
+    const user = userEvent.setup()
+    renderDashboard()
+    await screen.findByRole('table')
+
+    await user.type(
+      screen.getByLabelText('Search company or job title'),
+      'Globex',
+    )
+
+    await waitFor(() => {
+      const rows = tableBodyRows()
+      // Only the 2 Globex rows remain.
+      expect(rows).toHaveLength(2)
+    })
+    expect(
+      screen.getByText(/results \(filtered from 12\)/),
+    ).toBeInTheDocument()
+  })
+
+  it('filters by company when the dropdown changes', async () => {
+    const user = userEvent.setup()
+    renderDashboard()
+    await screen.findByRole('table')
+
+    await user.selectOptions(screen.getByLabelText('Filter by company'), 'Initech')
+
+    await waitFor(() => expect(tableBodyRows()).toHaveLength(2))
+    const table = screen.getByRole('table')
+    expect(within(table).queryByText('Globex')).toBeNull()
+  })
+
+  it('shows the empty state when filters match nothing', async () => {
+    const user = userEvent.setup()
+    renderDashboard()
+    await screen.findByRole('table')
+
+    await user.type(
+      screen.getByLabelText('Search company or job title'),
+      'no-such-company-xyz',
+    )
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No recruiter requests match your filters'),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('refreshes data when Refresh is clicked', async () => {
+    const user = userEvent.setup()
+    renderDashboard()
+    await screen.findByRole('table')
+    await user.click(screen.getByRole('button', { name: /Refresh/ }))
+    // Table remains after a successful refresh.
+    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
## Summary

Component tests for every dashboard component plus an MSW-backed integration test for `DashboardPage` (issue #39). **43 tests, all passing.**

| File | Coverage |
|---|---|
| StatsCards.jsx | 100% |
| FilterBar.jsx | 97% |
| RecruiterTable.jsx | 90% |
| DashboardPage.jsx | 100% lines |
| card.jsx / filters.js | 100% |
| **Overall (dashboard surface)** | **96% lines / 80% branches** — clears the 75% threshold |

### Component tests
- **StatsCards** — all four labels; null/undefined-stats fallback (zeros + N/A); top job title = max count; `vi.setSystemTime` makes the "This Month" UTC bucket deterministic.
- **FilterBar** — sorted/de-duped dropdown options from `allData`; debounced search push; immediate dropdown + month-range changes; Clear Filters visibility + reset; tolerates empty `allData`.
- **RecruiterTable** — empty state; row rendering; `recruiterLabel` → "Anonymous" fallback; default month-descending sort; asc/desc toggle via `aria-sort`; pagination (page size, controls, `onPageChange`, disabled Previous) and out-of-range page clamp.
- **card** — children + custom className passthrough.

### DashboardPage integration (MSW intercepts real `fetch`)
Loading state → data render → stats totals → error state + **Try Again** recovery → empty API response → search filtering → company-dropdown filtering → empty-filter state → refresh. Per the issue, MSW intercepts actual `fetch()` (not module mocks); interactions use `@testing-library/user-event`.

## Notes
- This PR is **stacked on #38** (`feat/38-setup-vitest-msw-fixtures`) because it needs that test infra to run. Its base is `feat/38-...`; **GitHub auto-retargets it to the epic when #38 merges**, keeping this diff limited to the test files.
- Added `coverage` to ESLint's `globalIgnores` so the generated v8 report isn't linted.

## Verification
- ✅ `npm run test` → 43 passing
- ✅ `npm run test:coverage` → exits 0 (thresholds met)
- ✅ `npm run lint` clean · `npm run build` OK

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)