### PR TITLE
ci: add GitHub Actions workflow for tests and Terraform validation (41)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,17 +94,29 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+          # A config error / early crash may leave no report; don't let a
+          # missing path turn into a second failure that masks the real one.
+          if-no-files-found: ignore
 
   # Detect whether any infra/ files changed so Terraform validation only runs
   # when relevant (per-job path gating; on.*.paths would gate the whole file).
   changes:
     name: Detect infra changes
     runs-on: ubuntu-latest
+    # paths-filter lists PR files via the API; grant the read scope explicitly
+    # so a hardened default token (contents: read only) can't 403 and silently
+    # skip Terraform validation while the workflow still reports green.
+    permissions:
+      pull-requests: read
     outputs:
       infra: ${{ steps.filter.outputs.infra }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        # Full history so paths-filter can diff on push events (the default
+        # fetch-depth: 1 leaves no base commit to compare against).
+        with:
+          fetch-depth: 0
 
       - name: Filter changed paths
         uses: dorny/paths-filter@v3
@@ -115,19 +127,31 @@ jobs:
               - 'infra/**'
 
   tf-validate:
-    name: Terraform validate
+    # Distinct from ci.yml's always-on "Terraform validate" check so the two
+    # are unambiguous when wired up as branch-protection required checks.
+    name: Terraform validate (test)
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.infra == 'true' }}
+    # The job always runs (no job-level `if`-skip) so it reports a conclusion
+    # even on frontend-only PRs — a skipped job never reports `success` and
+    # would leave a required check pending forever. The steps below no-op when
+    # infra/ is unchanged, so the job passes without doing Terraform work.
     steps:
+      - name: No infra changes — skip
+        if: ${{ needs.changes.outputs.infra != 'true' }}
+        run: echo "No infra/ changes; Terraform validation not required for this PR."
+
       - name: Checkout code
+        if: ${{ needs.changes.outputs.infra == 'true' }}
         uses: actions/checkout@v6
 
       - name: Setup Terraform
+        if: ${{ needs.changes.outputs.infra == 'true' }}
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.5.7'
 
       # init uses -backend=false (see the script), so no AWS credentials needed.
       - name: Validate Terraform
+        if: ${{ needs.changes.outputs.infra == 'true' }}
         run: ./infra/recruiter-dashboard/scripts/validate.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,133 @@
+name: Test
+
+# Runs the frontend test pyramid (lint -> unit -> e2e) plus Terraform
+# validation. Triggers on pushes to main and on every pull request (so the
+# Phase 5 epic's subtask PRs are checked too), matching ci.yml's PR trigger.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# Cancel superseded runs on the same ref. A distinct group from ci.yml so the
+# two workflows don't cancel each other.
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/
+          retention-days: 7
+
+  e2e-tests:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The Playwright projects are all Chromium-based, so only Chromium is
+      # needed. --with-deps installs the required OS libraries on the runner.
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+  # Detect whether any infra/ files changed so Terraform validation only runs
+  # when relevant (per-job path gating; on.*.paths would gate the whole file).
+  changes:
+    name: Detect infra changes
+    runs-on: ubuntu-latest
+    outputs:
+      infra: ${{ steps.filter.outputs.infra }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            infra:
+              - 'infra/**'
+
+  tf-validate:
+    name: Terraform validate
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.infra == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: '1.5.7'
+
+      # init uses -backend=false (see the script), so no AWS credentials needed.
+      - name: Validate Terraform
+        run: ./infra/recruiter-dashboard/scripts/validate.sh

--- a/infra/recruiter-dashboard/scripts/validate.sh
+++ b/infra/recruiter-dashboard/scripts/validate.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Terraform format-check and validation for the recruiter-dashboard config.
+#
+# Uses `terraform init -backend=false` so it needs no AWS credentials and never
+# touches remote state — safe to run in CI on every infra change. Resolves its
+# own directory, so it works from any working directory (CI or local).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TF_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$TF_DIR"
+
+echo "==> terraform fmt -check -recursive"
+terraform fmt -check -recursive
+
+echo "==> terraform init -backend=false"
+terraform init -backend=false
+
+echo "==> terraform validate"
+terraform validate
+
+echo "==> Terraform validation passed"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/test.yml` and `infra/recruiter-dashboard/scripts/validate.sh` (issue #41).

### Jobs
| Job | Does | Notes |
|---|---|---|
| `lint` | `npm ci` → `npm run lint` | gates the rest |
| `unit-tests` | `npm run test:coverage` → upload `coverage/` artifact | `needs: lint` |
| `e2e-tests` | install Chromium `--with-deps` → `npm run test:e2e` → upload Playwright report **on failure** | `needs: unit-tests` |
| `changes` | `dorny/paths-filter` → `infra` output | detects infra changes (`pull-requests: read`, full history) |
| `tf-validate` | `scripts/validate.sh` (fmt-check + `init -backend=false` + validate) | `needs: changes`; always runs, steps no-op when `infra/**` unchanged |

`lint → unit-tests → e2e-tests` run sequentially; `tf-validate` runs independently and only does Terraform work when `infra/**` changed. `concurrency` cancels superseded runs (group `test-${{ github.ref }}`, distinct from `ci.yml`).

### `scripts/validate.sh`
Resolves its own directory (works from any CWD), runs `terraform fmt -check -recursive`, `terraform init -backend=false`, `terraform validate`. **Verified locally** against the current config — fmt clean, validate `Success!`.

## Decisions / deviations
- **Trigger is `push: [main]` + `pull_request:` (all PRs)**, mirroring `ci.yml`. The issue says "PRs to main", but an unfiltered `pull_request` trigger is what lets this workflow validate the epic's own subtask PRs. (A `main`-only PR filter would skip every PR in this epic.)
- **Per-job path gating** for `tf-validate` uses `dorny/paths-filter@v3` (a `changes` job exposing an output) because `on.*.paths` would gate the whole workflow, not one job.
- **`tf-validate` always runs and no-ops when `infra/**` is unchanged** (rather than a job-level `if`-skip) so it always reports a conclusion — a skipped job never reports `success` and would leave a required check pending forever on frontend-only PRs.
- **Check named `Terraform validate (test)`** to stay distinct from `ci.yml`'s always-on `Terraform validate`, so the two are unambiguous as branch-protection required checks.
- **Playwright report uploaded `if: failure()`** (`if-no-files-found: ignore` so a missing report can't mask the real failure); coverage uploads unconditionally.
- Overlap with `ci.yml` (which also lints/builds/validates) is intentional for now — consolidating the two workflows is a reasonable follow-up but out of scope here.

## CI status
All checks green: `lint`, `unit-tests`, `e2e-tests`, `Terraform validate (test)`, plus `ci.yml`'s jobs. The earlier dependency on #38/#39/#40 is resolved — those landed in the epic, so `npm run test:coverage` and `npm run test:e2e` exist on this branch and both jobs run for real.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)
