### PR TITLE
chore(infra): migrate recruiter-dashboard to S3 backend + fix SES permission churn

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -16,4 +16,4 @@ steps:
 
   - uses: hashicorp/setup-terraform@v4
     with:
-      terraform_version: '1.5.7'
+      terraform_version: '1.15.5'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: '1.5.7'
+          terraform_version: '1.15.5'
 
       - name: Check formatting
         run: terraform fmt -check -recursive

--- a/infra/recruiter-dashboard/main.tf
+++ b/infra/recruiter-dashboard/main.tf
@@ -12,16 +12,13 @@ terraform {
     }
   }
 
-  # Local state for single-developer project.
-  # To migrate to S3 backend in the future, uncomment the block below:
-  #
-  # backend "s3" {
-  #   bucket         = "sh3r4rd-terraform-state"
-  #   key            = "recruiter-dashboard/terraform.tfstate"
-  #   region         = "us-east-1"
-  #   dynamodb_table = "terraform-locks"
-  #   encrypt        = true
-  # }
+  backend "s3" {
+    bucket         = "sh3r4rd-terraform-state"
+    key            = "recruiter-dashboard/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
 }
 
 provider "aws" {
@@ -127,13 +124,14 @@ module "api_gateway" {
 module "ses" {
   source = "./modules/ses"
 
-  ses_domain                = var.ses_domain
-  ses_recipient             = var.ses_recipient
-  aws_region                = var.aws_region
-  hosted_zone_id            = var.hosted_zone_id
-  s3_bucket_name            = module.s3.bucket_name
-  s3_key_prefix             = "${local.s3_key_prefix}/"
-  email_parser_function_arn = module.lambda_email_parser.function_arn
+  ses_domain                 = var.ses_domain
+  ses_recipient              = var.ses_recipient
+  aws_region                 = var.aws_region
+  hosted_zone_id             = var.hosted_zone_id
+  s3_bucket_name             = module.s3.bucket_name
+  s3_key_prefix              = "${local.s3_key_prefix}/"
+  email_parser_function_arn  = module.lambda_email_parser.function_arn
+  email_parser_function_name = module.lambda_email_parser.function_name
 }
 
 # ---------------------------------------------------------------------------

--- a/infra/recruiter-dashboard/main.tf
+++ b/infra/recruiter-dashboard/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.10.0"
 
   required_providers {
     aws = {
@@ -13,11 +13,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "sh3r4rd-terraform-state"
-    key            = "recruiter-dashboard/terraform.tfstate"
-    region         = "us-east-1"
-    dynamodb_table = "terraform-locks"
-    encrypt        = true
+    bucket       = "sh3r4rd-terraform-state"
+    key          = "recruiter-dashboard/terraform.tfstate"
+    region       = "us-east-1"
+    encrypt      = true
+    use_lockfile = true # S3-native state locking (replaces deprecated dynamodb_table)
   }
 }
 

--- a/infra/recruiter-dashboard/modules/ses/main.tf
+++ b/infra/recruiter-dashboard/modules/ses/main.tf
@@ -66,7 +66,7 @@ resource "aws_ses_active_receipt_rule_set" "this" {
 resource "aws_lambda_permission" "ses_invoke" {
   statement_id   = "AllowSESInvoke"
   action         = "lambda:InvokeFunction"
-  function_name  = var.email_parser_function_arn
+  function_name  = var.email_parser_function_name
   principal      = "ses.amazonaws.com"
   source_account = data.aws_caller_identity.current.account_id
 }

--- a/infra/recruiter-dashboard/modules/ses/variables.tf
+++ b/infra/recruiter-dashboard/modules/ses/variables.tf
@@ -23,6 +23,11 @@ variable "email_parser_function_arn" {
   type        = string
 }
 
+variable "email_parser_function_name" {
+  description = "Name of the email parser Lambda function (used for the invoke permission)."
+  type        = string
+}
+
 variable "hosted_zone_id" {
   description = "Route53 hosted zone ID for DNS record creation."
   type        = string


### PR DESCRIPTION
Closes #90

## Why

After re-cloning the repo, `terraform plan` in `infra/recruiter-dashboard/` wanted to **create ~56 resources that already exist in AWS** — because the backend was local and `*.tfstate` is gitignored, so the clone had no state. The work to reconcile state with reality was done out-of-band (state-only `terraform import` of 57 live resources + migration to S3); this PR carries the **configuration changes** that match that reconciled state.

## Changes

- **Enable S3 remote backend** in `main.tf` (`sh3r4rd-terraform-state` bucket, key `recruiter-dashboard/terraform.tfstate`, us-east-1, encrypted).
- **S3-native state locking** via `use_lockfile = true` (replaces the deprecated `dynamodb_table` lock param on Terraform 1.15.5); `required_version` bumped to `>= 1.10.0`.
- **Fix perpetual `ses_invoke` replacement**: the SES→Lambda invoke permission now receives the function **name** (which AWS stores/returns) instead of the ARN, eliminating a spurious diff on every plan. The receipt rule continues to use the ARN, which it requires. Adds `email_parser_function_name` var to `modules/ses`.

## Result

`terraform plan` no longer recreates live infrastructure. Remaining diff is benign: the API Gateway deployment always re-plans (un-importable `triggers` hash, safe under `create_before_destroy`), plus cosmetic AWS provider v6.34 / `last_modified` drift.

## Notes

- `terraform.tfvars` (`alert_email`) was also reconciled to the live SNS subscription endpoint, but it's gitignored and not part of this PR.
- The previously bootstrapped `terraform-locks` DynamoDB table was deleted once `use_lockfile` replaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)