### PR TITLE
feat(infra): serve dashboard API via dedicated subdomain (fix /recruiters 403)

### DIFF
--- a/.claude/rules/terraform.md
+++ b/.claude/rules/terraform.md
@@ -21,7 +21,7 @@ Each module in `infra/recruiter-dashboard/modules/<name>/`:
 | `lambda` | Lambda function deployment (arm64) |
 | `iam` | Roles, policies, log group ARN construction |
 | `ses` | Email receiving on `inbox.sh3r4rd.com` |
-| `api-gateway` | REST API at `api.sh3r4rd.com` |
+| `api-gateway` | REST API at `dashboard-api.sh3r4rd.com` |
 | `monitoring` | CloudWatch alarms, budget alerts via SNS |
 
 ## DynamoDB Schema

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [`terraform.tfvars.example`](infra/recruiter-dashboard/terraform.tfvars.exam
 The recruiter dashboard is built and deployed. It includes:
 
 - **Email parsing pipeline** — SES receives recruiter emails, stores raw emails in S3, triggers a Go Lambda that parses the email, extracts recruiter data via OpenAI, and writes structured records to DynamoDB
-- **API handler** — Go Lambda behind API Gateway at `api.sh3r4rd.com` serving anonymized recruiter data. Endpoints: `GET /recruiters` (list with `?company=` and `?month=` filters), `GET /recruiters/{id}`, `GET /stats` (aggregate statistics)
+- **API handler** — Go Lambda behind API Gateway at `dashboard-api.sh3r4rd.com` serving anonymized recruiter data. Endpoints: `GET /recruiters` (list with `?company=` and `?month=` filters), `GET /recruiters/{id}`, `GET /stats` (aggregate statistics)
 
 ## Backend Development
 

--- a/infra/recruiter-dashboard/AGENTS.md
+++ b/infra/recruiter-dashboard/AGENTS.md
@@ -43,7 +43,7 @@ SES receives email → stores raw email in S3 → triggers email-parser Lambda �
 | `modules/lambda` | Lambda function deployment (arm64) |
 | `modules/iam` | Roles, policies, log group ARN construction |
 | `modules/ses` | Email receiving on `inbox.sh3r4rd.com` |
-| `modules/api-gateway` | REST API at `api.sh3r4rd.com` |
+| `modules/api-gateway` | REST API at `dashboard-api.sh3r4rd.com` |
 | `modules/monitoring` | CloudWatch alarms, budget alerts via SNS |
 
 ## Terraform Conventions

--- a/infra/recruiter-dashboard/main.tf
+++ b/infra/recruiter-dashboard/main.tf
@@ -116,6 +116,8 @@ module "api_gateway" {
   api_handler_invoke_arn    = module.lambda_api_handler.invoke_arn
   api_handler_function_name = module.lambda_api_handler.function_name
   cors_allowed_origin       = var.cors_allowed_origin
+  custom_domain_name        = var.dashboard_api_domain
+  hosted_zone_id            = var.hosted_zone_id
 }
 
 # ---------------------------------------------------------------------------

--- a/infra/recruiter-dashboard/modules/api-gateway/main.tf
+++ b/infra/recruiter-dashboard/modules/api-gateway/main.tf
@@ -309,3 +309,72 @@ resource "aws_lambda_permission" "api_gateway" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.api.execution_arn}/${aws_api_gateway_stage.prod.stage_name}/*"
 }
+
+# ---------------------------------------------------------------------------
+# Custom domain — dedicated subdomain fronting the prod stage
+# ---------------------------------------------------------------------------
+
+# ACM certificate for the custom domain (REGIONAL — must be in the API's region).
+resource "aws_acm_certificate" "api" {
+  domain_name       = var.custom_domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# DNS records that prove domain ownership to ACM.
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.api.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id         = var.hosted_zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+# Blocks until the certificate is validated and ISSUED.
+resource "aws_acm_certificate_validation" "api" {
+  certificate_arn         = aws_acm_certificate.api.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
+# Regional custom domain, using the validated certificate.
+resource "aws_api_gateway_domain_name" "api" {
+  domain_name              = var.custom_domain_name
+  regional_certificate_arn = aws_acm_certificate_validation.api.certificate_arn
+  security_policy          = "TLS_1_2"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
+# Map the domain root to the prod stage (no base path).
+resource "aws_api_gateway_base_path_mapping" "api" {
+  domain_name = aws_api_gateway_domain_name.api.domain_name
+  api_id      = aws_api_gateway_rest_api.api.id
+  stage_name  = aws_api_gateway_stage.prod.stage_name
+}
+
+# Alias the custom domain to the API Gateway regional endpoint.
+resource "aws_route53_record" "api_alias" {
+  zone_id = var.hosted_zone_id
+  name    = var.custom_domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_api_gateway_domain_name.api.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.api.regional_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/infra/recruiter-dashboard/modules/api-gateway/outputs.tf
+++ b/infra/recruiter-dashboard/modules/api-gateway/outputs.tf
@@ -12,3 +12,13 @@ output "stage_name" {
   description = "Name of the deployed stage."
   value       = aws_api_gateway_stage.prod.stage_name
 }
+
+output "custom_domain_url" {
+  description = "HTTPS URL of the custom domain fronting the prod stage."
+  value       = "https://${aws_api_gateway_domain_name.api.domain_name}"
+}
+
+output "custom_domain_regional_target" {
+  description = "Regional domain name the custom domain alias points to (for diagnostics)."
+  value       = aws_api_gateway_domain_name.api.regional_domain_name
+}

--- a/infra/recruiter-dashboard/modules/api-gateway/variables.tf
+++ b/infra/recruiter-dashboard/modules/api-gateway/variables.tf
@@ -23,6 +23,26 @@ variable "cors_allowed_origin" {
   }
 }
 
+variable "custom_domain_name" {
+  description = "Custom domain name for the REST API (e.g. dashboard-api.sh3r4rd.com)."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$", var.custom_domain_name))
+    error_message = "Must be a valid domain name."
+  }
+}
+
+variable "hosted_zone_id" {
+  description = "Route53 hosted zone ID for ACM DNS validation and the custom domain alias record."
+  type        = string
+
+  validation {
+    condition     = can(regex("^Z[A-Z0-9]+$", var.hosted_zone_id))
+    error_message = "Must be a valid Route53 hosted zone ID (starts with Z, alphanumeric)."
+  }
+}
+
 variable "throttling_rate_limit" {
   description = "Steady-state requests per second for stage throttling."
   type        = number

--- a/infra/recruiter-dashboard/outputs.tf
+++ b/infra/recruiter-dashboard/outputs.tf
@@ -43,6 +43,11 @@ output "api_endpoint" {
   value       = module.api_gateway.api_endpoint
 }
 
+output "dashboard_api_url" {
+  description = "HTTPS URL of the custom subdomain fronting the dashboard API."
+  value       = module.api_gateway.custom_domain_url
+}
+
 output "ses_domain_verification_id" {
   description = "The verified SES domain name (resource exists only after verification succeeds)."
   value       = module.ses.domain_verification_id

--- a/infra/recruiter-dashboard/terraform.tfvars.example
+++ b/infra/recruiter-dashboard/terraform.tfvars.example
@@ -13,8 +13,10 @@ ses_recipient = "recruiters@inbox.example.com"
 # CORS allowed origin for API Gateway
 cors_allowed_origin = "https://example.com"
 
-# Custom subdomain that fronts the recruiter dashboard API prod stage
-dashboard_api_domain = "dashboard-api.example.com"
+# Custom subdomain that fronts the recruiter dashboard API prod stage.
+# Optional — defaults to "dashboard-api.sh3r4rd.com" (see variables.tf). Uncomment
+# only to override; leaving it commented preserves the working default.
+# dashboard_api_domain = "dashboard-api.example.com"
 
 # Email address for alarm notifications
 alert_email = "alerts@example.com"

--- a/infra/recruiter-dashboard/terraform.tfvars.example
+++ b/infra/recruiter-dashboard/terraform.tfvars.example
@@ -13,6 +13,9 @@ ses_recipient = "recruiters@inbox.example.com"
 # CORS allowed origin for API Gateway
 cors_allowed_origin = "https://example.com"
 
+# Custom subdomain that fronts the recruiter dashboard API prod stage
+dashboard_api_domain = "dashboard-api.example.com"
+
 # Email address for alarm notifications
 alert_email = "alerts@example.com"
 

--- a/infra/recruiter-dashboard/variables.tf
+++ b/infra/recruiter-dashboard/variables.tf
@@ -45,6 +45,17 @@ variable "cors_allowed_origin" {
   }
 }
 
+variable "dashboard_api_domain" {
+  description = "Custom subdomain that fronts the recruiter dashboard API prod stage."
+  type        = string
+  default     = "dashboard-api.sh3r4rd.com"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$", var.dashboard_api_domain))
+    error_message = "Must be a valid domain name."
+  }
+}
+
 variable "alert_email" {
   description = "Email address for budget and alarm notifications."
   type        = string

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -3,7 +3,9 @@ import { RECRUITERS, STATS } from './fixtures'
 
 // Base URL of the production API the dashboard talks to. The dashboard
 // hardcodes this origin (no env var), so the mocks target it directly.
-export const API_BASE = 'https://api.sh3r4rd.com'
+// Note: the dashboard API lives on its own subdomain; the resume form's
+// /requests endpoint is a separate API on api.sh3r4rd.com and is not mocked here.
+export const API_BASE = 'https://dashboard-api.sh3r4rd.com'
 
 // Default happy-path handlers. Tests override these per-case with
 // `server.use(...)` to simulate errors, empty results, or custom datasets.

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -7,8 +7,8 @@ import FilterBar from "../components/sections/FilterBar";
 import RecruiterTable from "../components/sections/RecruiterTable";
 import { EMPTY_FILTERS } from "../lib/filters";
 
-const RECRUITERS_URL = "https://api.sh3r4rd.com/recruiters";
-const STATS_URL = "https://api.sh3r4rd.com/stats";
+const RECRUITERS_URL = "https://dashboard-api.sh3r4rd.com/recruiters";
+const STATS_URL = "https://dashboard-api.sh3r4rd.com/stats";
 const PAGE_SIZE = 10;
 
 function matchesFilters(item, filters) {


### PR DESCRIPTION
## Why

`GET https://api.sh3r4rd.com/recruiters` (and `/stats`) returned **403**. Diagnosis via AWS CLI: `api.sh3r4rd.com`'s root base-path maps to the **Communications** API (`pfo0xx2l8i`/`DEV`, which only serves `POST /requests` for the resume form). The dashboard routes live on a **different** API — `recruiter-dashboard-api` (`5eemi9tlle`/`prod`) — that no domain pointed to. A custom-domain root maps to one API and base-path mappings strip their prefix, so `/recruiters` and `/requests` can't share the bare host.

## What

Give the dashboard API its own subdomain, fully IaC, leaving `api.sh3r4rd.com` and the resume form untouched.

**Terraform (`modules/api-gateway/`):** new REGIONAL custom domain `dashboard-api.sh3r4rd.com` → recruiter `prod` stage:
- `aws_acm_certificate` (DNS-validated) + Route53 validation records + `aws_acm_certificate_validation`
- `aws_api_gateway_domain_name` (REGIONAL, TLS_1_2) + `aws_api_gateway_base_path_mapping` (root → prod)
- `aws_route53_record` alias → the regional endpoint
- New `dashboard_api_domain` root variable + `dashboard_api_url` output

**Frontend:** `DashboardPage.jsx` and the MSW `handlers.js` base now target `dashboard-api.sh3r4rd.com`. `ResumeRequestPage.jsx` `/requests` is unchanged.

## Verification
- `terraform apply` (scoped to `module.api_gateway`): **6 added, 0 changed, 0 destroyed**.
- `curl https://dashboard-api.sh3r4rd.com/recruiters` → `200 []`, `/stats` → `200 {"totalEmails":0,...}` (consistent after propagation).
- Regression: `OPTIONS https://api.sh3r4rd.com/requests` → `200` (resume form unaffected).
- `npm test` 43/43, `npm run build` ✅, `npm run lint` ✅, `terraform validate` ✅.

## Notes
- Infra is **already applied**; production will use the subdomain once this merges and `deploy.yml` ships the rebuilt frontend.
- Unrelated pre-existing S3 SSE-C drift was deliberately **not** applied here — tracked in #98.

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)