### PR TITLE
fix(infra): grant api-handler dynamodb:PutItem for stats cache

### DIFF
--- a/docs/architecture-recruiter-dashboard.md
+++ b/docs/architecture-recruiter-dashboard.md
@@ -169,8 +169,11 @@ responses carry CORS headers
   also stored for future cross-message dedup, but is not yet part of the idempotency guarantee.
 - **Least privilege:** email-parser role can read/tag S3 + write DynamoDB + read one SSM param;
   api-handler role is DynamoDB read (`GetItem`/`Query`/`Scan` on table + both GSIs) plus a
-  single narrowly-scoped `PutItem` on the base table only — used solely to write the `/stats`
-  cache item (`STATS#cache`). It cannot write to either GSI.
+  single narrowly-scoped `PutItem` — constrained by a `dynamodb:LeadingKeys` condition to the
+  partition key `STATS#cache`, so it can only write the `/stats` cache item and no other
+  DynamoDB write actions are granted. (The cache item does not appear in either GSI because it
+  lacks the GSI key attributes, not because of resource scoping — `PutItem` is always evaluated
+  against the table and indexes update automatically.)
 
 ---
 *Generated from source review of `infra/recruiter-dashboard/` (Terraform + Go Lambdas) and `src/` (React).*

--- a/docs/architecture-recruiter-dashboard.md
+++ b/docs/architecture-recruiter-dashboard.md
@@ -150,7 +150,7 @@ Trigger: **API Gateway `AWS_PROXY`** (synchronous).
 |-------|-----------------|-------|
 | `GET /recruiters` | `?month=` → Query **date-index** GSI; `?company=` → Scan + `contains(company)`; neither → full Scan | All exclude `STATS#cache`; sorted by `received_at` desc. **The dashboard UI calls this with no params and filters client-side**, so only the full-Scan branch is exercised in practice |
 | `GET /recruiters/{id}` | Query main table by `id` PK, `Limit 1`, desc | 404 on `STATS#cache` |
-| `GET /stats` | `GetItem` cache → on miss/expiry, projected Scan + aggregate | Attempts a 5-min TTL cache `PutItem`, but the api-handler role is read-only, so the write is denied (`AccessDenied`) and stats serve uncached. The error is non-fatal |
+| `GET /stats` | `GetItem` cache → on miss/expiry, projected Scan + aggregate, then `PutItem` to refresh the cache | Writes a 5-min TTL cache item (`STATS#cache` / `CACHE`); subsequent requests serve from cache until expiry. The `PutItem` is non-fatal — a write failure just means the next request re-scans |
 
 Every response passes through **`anonymizer.go`**, which strips PII (`recruiter_email`,
 `first_name`, `last_name`, `phone`, `s3_key`, `s3_bucket`, `dedup_key`), derives a public
@@ -168,8 +168,9 @@ responses carry CORS headers
   (`attribute_not_exists(id) AND attribute_not_exists(received_at)`). A SHA-256 `dedup_key` is
   also stored for future cross-message dedup, but is not yet part of the idempotency guarantee.
 - **Least privilege:** email-parser role can read/tag S3 + write DynamoDB + read one SSM param;
-  api-handler role is DynamoDB read-only (`GetItem`/`Query`/`Scan` on table + both GSIs). One
-  consequence: the `/stats` cache `PutItem` is denied at runtime, so stats serve uncached.
+  api-handler role is DynamoDB read (`GetItem`/`Query`/`Scan` on table + both GSIs) plus a
+  single narrowly-scoped `PutItem` on the base table only — used solely to write the `/stats`
+  cache item (`STATS#cache`). It cannot write to either GSI.
 
 ---
 *Generated from source review of `infra/recruiter-dashboard/` (Terraform + Go Lambdas) and `src/` (React).*

--- a/infra/recruiter-dashboard/modules/iam/main.tf
+++ b/infra/recruiter-dashboard/modules/iam/main.tf
@@ -111,13 +111,21 @@ data "aws_iam_policy_document" "api_handler" {
     )
   }
 
-  # DynamoDB: Write the STATS#cache sentinel item (table only, no GSIs).
-  # Scoped narrowly to preserve least privilege; the api-handler otherwise
-  # only reads.
+  # DynamoDB: Write the STATS#cache sentinel item only.
+  # Scoped narrowly to preserve least privilege; the LeadingKeys condition
+  # restricts PutItem to the single item whose partition key (id) is
+  # "STATS#cache", so the api-handler cannot overwrite or inject recruiter
+  # rows. It otherwise only reads.
   statement {
     sid       = "DynamoDBStatsCacheWrite"
     actions   = ["dynamodb:PutItem"]
     resources = [var.dynamodb_table_arn]
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      variable = "dynamodb:LeadingKeys"
+      values   = ["STATS#cache"]
+    }
   }
 
   # CloudWatch Logs

--- a/infra/recruiter-dashboard/modules/iam/main.tf
+++ b/infra/recruiter-dashboard/modules/iam/main.tf
@@ -87,7 +87,8 @@ resource "aws_iam_role_policy" "email_parser" {
 
 # ---------------------------------------------------------------------------
 # API Handler Lambda Role
-# Permissions: DynamoDB read-only (table + GSIs), CloudWatch logs
+# Permissions: DynamoDB read (table + GSIs) + stats-cache write (table only),
+# CloudWatch logs
 # ---------------------------------------------------------------------------
 
 resource "aws_iam_role" "api_handler" {
@@ -96,7 +97,7 @@ resource "aws_iam_role" "api_handler" {
 }
 
 data "aws_iam_policy_document" "api_handler" {
-  # DynamoDB: Read-only access to table and GSIs
+  # DynamoDB: Read access to table and GSIs
   statement {
     sid = "DynamoDBReadOnly"
     actions = [
@@ -108,6 +109,15 @@ data "aws_iam_policy_document" "api_handler" {
       [var.dynamodb_table_arn],
       var.dynamodb_gsi_arns
     )
+  }
+
+  # DynamoDB: Write the STATS#cache sentinel item (table only, no GSIs).
+  # Scoped narrowly to preserve least privilege; the api-handler otherwise
+  # only reads.
+  statement {
+    sid       = "DynamoDBStatsCacheWrite"
+    actions   = ["dynamodb:PutItem"]
+    resources = [var.dynamodb_table_arn]
   }
 
   # CloudWatch Logs


### PR DESCRIPTION
## Summary

Fixes #102. The `api-handler` Lambda writes a `STATS#cache` sentinel item to refresh the 5-minute `/stats` TTL cache (`handler.go:198`), but its IAM role only granted `GetItem`/`Query`/`Scan`. Every cache write failed with `AccessDeniedException` (handled non-fatally), so the cache was never populated and **every `GET /stats` request fell through to a full projected Scan + aggregate**.

## Changes

- **`modules/iam/main.tf`** — Add a separate least-privilege `DynamoDBStatsCacheWrite` statement granting `dynamodb:PutItem` scoped to the **base table ARN only** (no GSIs — the cache item lives on the base table). Update the two stale "read-only" comments.
- **`docs/architecture-recruiter-dashboard.md`** — Rewrite the `/stats` row and least-privilege bullet to describe the corrected cached behavior instead of the broken state (this doc, from #101, is what surfaced the bug).

No Go changes needed — `handler_test.go` already asserts `PutItem` is called.

## Verification

- `terraform fmt -recursive` — clean
- `terraform validate` — Success! The configuration is valid.
- api-handler Go tests — `ok`

## Post-merge / apply steps

The fix is inert until `terraform apply` runs (IAM-only change, no resource replacement). After applying, allow a few seconds for IAM propagation, then:
1. Hit `GET /stats` twice — confirm the 2nd is cache-served.
2. Confirm no `AccessDeniedException` in the api-handler CloudWatch logs.
3. Confirm a `STATS#cache` / `CACHE` item with `stats_ttl` ~5 min out exists in `recruiter_emails`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)