### PR TITLE
feat(infra): back up terraform.tfvars to SSM via sync script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ terraform -chdir=infra/recruiter-dashboard fmt -check -recursive
 terraform -chdir=infra/recruiter-dashboard plan
 ```
 
+`infra/recruiter-dashboard/terraform.tfvars` is git-ignored; its source of truth is the SSM SecureString `/recruiter-dashboard/tfvars` (us-east-1), synced via `scripts/tfvars.sh`. Run `make tf-vars-pull` before `plan`/`apply`, `make tf-vars-push` after editing the file, `make tf-vars-diff` to check drift.
+
 ### All-in-one CI check
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,14 @@ All commands run from `infra/recruiter-dashboard/`:
 - **Format:** `terraform -chdir=infra/recruiter-dashboard fmt -recursive`
 - **Plan:** `terraform -chdir=infra/recruiter-dashboard plan`
 
+#### terraform.tfvars (sourced from SSM)
+
+`infra/recruiter-dashboard/terraform.tfvars` is git-ignored; its durable, versioned source of truth is the SSM SecureString parameter `/recruiter-dashboard/tfvars` (us-east-1). Terraform code is unaware of this — `scripts/tfvars.sh` mirrors the file verbatim to/from SSM.
+
+- **Before `plan`/`apply`:** `make tf-vars-pull` (fetch latest from SSM)
+- **After editing the file:** `make tf-vars-push` (back up to SSM as a new version)
+- **Check for drift:** `make tf-vars-diff`
+
 ## Architecture
 
 ### Frontend

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,16 @@ tf-fmt-check:
 tf-plan:
 	@terraform -chdir=$(INFRA_DIR) plan
 
+# terraform.tfvars <-> SSM sync (SSM is the durable source of truth; the file is git-ignored)
+tf-vars-pull:
+	@$(INFRA_DIR)/scripts/tfvars.sh pull
+
+tf-vars-push:
+	@$(INFRA_DIR)/scripts/tfvars.sh push
+
+tf-vars-diff:
+	@$(INFRA_DIR)/scripts/tfvars.sh diff
+
 # Clean build artifacts
 clean:
 	@rm -rf dist $(BUILD_DIR)

--- a/infra/recruiter-dashboard/.gitignore
+++ b/infra/recruiter-dashboard/.gitignore
@@ -5,6 +5,8 @@
 
 # Variables with secrets
 terraform.tfvars
+# Local backup written by scripts/tfvars.sh pull
+terraform.tfvars.bak
 
 # Crash logs
 crash.log

--- a/infra/recruiter-dashboard/AGENTS.md
+++ b/infra/recruiter-dashboard/AGENTS.md
@@ -21,7 +21,16 @@ terraform init
 terraform validate
 terraform fmt -check -recursive
 terraform plan
+
+# terraform.tfvars sync (SSM is the source of truth; the file is git-ignored)
+make -C ../.. tf-vars-pull   # before plan/apply
+make -C ../.. tf-vars-push   # after editing terraform.tfvars
+make -C ../.. tf-vars-diff   # check drift vs SSM
 ```
+
+## terraform.tfvars (sourced from SSM)
+
+`terraform.tfvars` is git-ignored; its durable, versioned source of truth is the SSM SecureString parameter `/recruiter-dashboard/tfvars` (us-east-1). `scripts/tfvars.sh` mirrors the file verbatim to/from SSM (`pull`/`push`/`diff`) — Terraform code is unaware of it. Run `make tf-vars-pull` before `plan`/`apply` and `make tf-vars-push` after editing the file.
 
 ## Email Parsing Pipeline
 

--- a/infra/recruiter-dashboard/CLAUDE.md
+++ b/infra/recruiter-dashboard/CLAUDE.md
@@ -18,7 +18,16 @@ make -C ../.. build-lambdas
 terraform init
 terraform validate
 terraform fmt -check -recursive
+
+# terraform.tfvars sync (SSM is the source of truth; the file is git-ignored)
+make -C ../.. tf-vars-pull   # before plan/apply
+make -C ../.. tf-vars-push   # after editing terraform.tfvars
+make -C ../.. tf-vars-diff   # check drift vs SSM
 ```
+
+## terraform.tfvars (sourced from SSM)
+
+`terraform.tfvars` is git-ignored; its durable, versioned source of truth is the SSM SecureString parameter `/recruiter-dashboard/tfvars` (us-east-1). `scripts/tfvars.sh` mirrors the file verbatim to/from SSM (`pull`/`push`/`diff`) — Terraform code is unaware of it. Run `make tf-vars-pull` before `plan`/`apply` and `make tf-vars-push` after editing the file.
 
 ## Lambda Functions
 

--- a/infra/recruiter-dashboard/scripts/tfvars.sh
+++ b/infra/recruiter-dashboard/scripts/tfvars.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# tfvars.sh — sync infra/recruiter-dashboard/terraform.tfvars to/from AWS SSM.
+#
+# SSM Parameter Store is the durable, versioned source of truth for the
+# git-ignored terraform.tfvars file. This script mirrors the file verbatim into
+# a single SecureString parameter. Terraform itself is unaware of any of this.
+#
+#   pull   SSM -> local file (backs up + confirms before overwriting local edits)
+#   push   local file -> SSM (refuses empty/missing local; confirms before overwrite)
+#   diff   show local-vs-remote differences; never writes
+#
+# Region is hardcoded so the script never depends on AWS_DEFAULT_REGION, but it
+# still respects AWS_PROFILE for credential selection.
+set -euo pipefail
+
+PARAM_NAME="/recruiter-dashboard/tfvars"
+REGION="us-east-1"
+
+# Resolve terraform.tfvars to an absolute path relative to this script's own
+# location (scripts/ lives one level under the terraform root), so the script
+# works regardless of the caller's working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TFVARS="$(cd "$SCRIPT_DIR/.." && pwd)/terraform.tfvars"
+BACKUP="$TFVARS.bak"
+
+# Temp file cleaned up on exit (set by pull). Initialized empty for `set -u`.
+TMPFILE=""
+cleanup() { [[ -n "$TMPFILE" ]] && rm -f "$TMPFILE"; return 0; }
+trap cleanup EXIT
+
+usage() {
+  echo "Usage: tfvars.sh {pull|push|diff} [--force]" >&2
+  exit 2
+}
+
+# Fetch the raw remote parameter value on stdout (no trailing-newline guarantee:
+# command substitution in callers strips trailing newlines anyway). Callers must
+# re-add exactly one trailing newline via `emit_remote` when writing/comparing,
+# so round-trips match the canonical terraform.tfvars form (one trailing \n).
+#
+# Returns 10 if the parameter does not exist yet; any other non-zero on error.
+read_remote() {
+  local out
+  if ! out="$(aws ssm get-parameter \
+      --name "$PARAM_NAME" \
+      --with-decryption \
+      --region "$REGION" \
+      --query Parameter.Value \
+      --output text 2>&1)"; then
+    if printf '%s' "$out" | grep -q "ParameterNotFound"; then
+      return 10
+    fi
+    echo "$out" >&2
+    return 1
+  fi
+  printf '%s' "$out"
+}
+
+# Print a captured remote value normalized to exactly one trailing newline.
+emit_remote() { printf '%s\n' "$1"; }
+
+confirm() {
+  # $1 = prompt. Honors a global FORCE flag for non-interactive use.
+  if [[ "${FORCE:-0}" == "1" ]]; then
+    return 0
+  fi
+  local reply
+  read -r -p "$1 [y/N] " reply
+  [[ "$reply" == "y" || "$reply" == "Y" ]]
+}
+
+cmd_pull() {
+  local remote rc
+  set +e
+  remote="$(read_remote)"
+  rc=$?
+  set -e
+  if [[ $rc -eq 10 ]]; then
+    echo "Parameter $PARAM_NAME not seeded yet — run 'make tf-vars-push' first." >&2
+    exit 1
+  elif [[ $rc -ne 0 ]]; then
+    exit $rc
+  fi
+
+  TMPFILE="$(mktemp)"
+  emit_remote "$remote" >"$TMPFILE"
+
+  if [[ -f "$TFVARS" ]]; then
+    if diff -u "$TFVARS" "$TMPFILE" >/dev/null 2>&1; then
+      echo "Local terraform.tfvars already matches SSM. Nothing to do."
+      return 0
+    fi
+    echo "Local terraform.tfvars differs from SSM:"
+    diff -u "$TFVARS" "$TMPFILE" || true
+    echo
+    if ! confirm "Overwrite local file? (a backup will be written to terraform.tfvars.bak)"; then
+      echo "Aborted." >&2
+      exit 1
+    fi
+    cp "$TFVARS" "$BACKUP"
+    echo "Backed up current local file to terraform.tfvars.bak"
+  fi
+
+  cp "$TMPFILE" "$TFVARS"
+  echo "Pulled $PARAM_NAME -> terraform.tfvars"
+}
+
+cmd_push() {
+  if [[ ! -s "$TFVARS" ]]; then
+    echo "Refusing to push: terraform.tfvars is missing or empty (would wipe remote)." >&2
+    exit 1
+  fi
+
+  local remote rc
+  set +e
+  remote="$(read_remote)"
+  rc=$?
+  set -e
+
+  if [[ $rc -eq 0 ]]; then
+    if emit_remote "$remote" | diff -u - "$TFVARS" >/dev/null 2>&1; then
+      echo "Already up to date — local matches SSM."
+      return 0
+    fi
+    echo "Local terraform.tfvars differs from SSM (remote <-> local):"
+    emit_remote "$remote" | diff -u --label "ssm:$PARAM_NAME" --label "local:terraform.tfvars" - "$TFVARS" || true
+    echo
+  elif [[ $rc -eq 10 ]]; then
+    echo "Parameter $PARAM_NAME does not exist yet — this push will create it (version 1)."
+  else
+    exit $rc
+  fi
+
+  if ! confirm "Push local terraform.tfvars to $PARAM_NAME?"; then
+    echo "Aborted." >&2
+    exit 1
+  fi
+
+  aws ssm put-parameter \
+    --name "$PARAM_NAME" \
+    --type SecureString \
+    --value file://"$TFVARS" \
+    --tier Intelligent-Tiering \
+    --overwrite \
+    --region "$REGION" >/dev/null
+  echo "Pushed terraform.tfvars -> $PARAM_NAME"
+}
+
+cmd_diff() {
+  local remote rc
+  set +e
+  remote="$(read_remote)"
+  rc=$?
+  set -e
+
+  if [[ $rc -eq 10 ]]; then
+    echo "Parameter $PARAM_NAME not seeded yet — run 'make tf-vars-push' first." >&2
+    exit 1
+  elif [[ $rc -ne 0 ]]; then
+    exit $rc
+  fi
+
+  if [[ ! -f "$TFVARS" ]]; then
+    echo "No local terraform.tfvars — run 'make tf-vars-pull' to fetch it." >&2
+    exit 1
+  fi
+
+  if emit_remote "$remote" | diff -u - "$TFVARS" >/dev/null 2>&1; then
+    echo "No drift — local terraform.tfvars matches SSM."
+    return 0
+  fi
+  echo "Drift detected (remote <-> local):"
+  emit_remote "$remote" | diff -u --label "ssm:$PARAM_NAME" --label "local:terraform.tfvars" - "$TFVARS" || true
+}
+
+main() {
+  local sub="${1:-}"
+  [[ -n "$sub" ]] || usage
+  shift || true
+
+  FORCE=0
+  for arg in "$@"; do
+    case "$arg" in
+      --force) FORCE=1 ;;
+      *) echo "Unknown option: $arg" >&2; usage ;;
+    esac
+  done
+
+  case "$sub" in
+    pull) cmd_pull ;;
+    push) cmd_push ;;
+    diff) cmd_diff ;;
+    *) usage ;;
+  esac
+}
+
+main "$@"

--- a/infra/recruiter-dashboard/scripts/tfvars.sh
+++ b/infra/recruiter-dashboard/scripts/tfvars.sh
@@ -112,6 +112,17 @@ cmd_push() {
     exit 1
   fi
 
+  # Canonicalize the local file to the same one-trailing-newline form that
+  # emit_remote produces, so the comparison below and the uploaded value match
+  # the remote round-trip exactly. Without this, a local file saved without a
+  # trailing newline would create a permanent phantom diff that "Already up to
+  # date" could never satisfy. Command substitution strips trailing newlines;
+  # emit_remote re-adds exactly one.
+  local local_canon
+  local_canon="$(cat "$TFVARS")"
+  TMPFILE="$(mktemp)"
+  emit_remote "$local_canon" >"$TMPFILE"
+
   local remote rc
   set +e
   remote="$(read_remote)"
@@ -119,12 +130,12 @@ cmd_push() {
   set -e
 
   if [[ $rc -eq 0 ]]; then
-    if emit_remote "$remote" | diff -u - "$TFVARS" >/dev/null 2>&1; then
+    if emit_remote "$remote" | diff -u - "$TMPFILE" >/dev/null 2>&1; then
       echo "Already up to date — local matches SSM."
       return 0
     fi
     echo "Local terraform.tfvars differs from SSM (remote <-> local):"
-    emit_remote "$remote" | diff -u --label "ssm:$PARAM_NAME" --label "local:terraform.tfvars" - "$TFVARS" || true
+    emit_remote "$remote" | diff -u --label "ssm:$PARAM_NAME" --label "local:terraform.tfvars" - "$TMPFILE" || true
     echo
   elif [[ $rc -eq 10 ]]; then
     echo "Parameter $PARAM_NAME does not exist yet — this push will create it (version 1)."
@@ -140,7 +151,7 @@ cmd_push() {
   aws ssm put-parameter \
     --name "$PARAM_NAME" \
     --type SecureString \
-    --value file://"$TFVARS" \
+    --value file://"$TMPFILE" \
     --tier Intelligent-Tiering \
     --overwrite \
     --region "$REGION" >/dev/null

--- a/infra/recruiter-dashboard/terraform.tfvars.example
+++ b/infra/recruiter-dashboard/terraform.tfvars.example
@@ -1,3 +1,7 @@
+# NOTE: The real terraform.tfvars is git-ignored and its source of truth is the
+# AWS SSM parameter /recruiter-dashboard/tfvars (us-east-1). Run `make tf-vars-pull`
+# to populate the real file from SSM. This example is only a fallback template.
+
 # AWS Region — must be SES-receiving-capable (us-east-1, us-west-2, eu-west-1)
 aws_region = "us-east-1"
 


### PR DESCRIPTION
Closes #96.

Makes AWS SSM Parameter Store the durable, versioned source of truth for the git-ignored `infra/recruiter-dashboard/terraform.tfvars`. Terraform code is **unchanged** — a new sync script mirrors the file verbatim to/from a single SecureString parameter.

## Changes
- **`infra/recruiter-dashboard/scripts/tfvars.sh`** (new, executable) — `pull` / `push` / `diff` subcommands. Region hardcoded to `us-east-1` (respects `AWS_PROFILE`); path resolved absolute from the script's own location.
- **`Makefile`** — `tf-vars-pull`, `tf-vars-push`, `tf-vars-diff` (not wired into `tf-plan` — pull/push stay explicit).
- **`.gitignore`** — ignore `terraform.tfvars.bak`.
- **`terraform.tfvars.example`** — header noting SSM is the source of truth.
- **Docs (4):** root + infra `CLAUDE.md`/`AGENTS.md` document the pull-before-plan / push-after-edit / diff-for-drift workflow.

## Safety guards
- `pull`: diffs, backs up local to `terraform.tfvars.bak`, and confirms before overwriting local edits.
- `push`: refuses an empty/missing local file (won't wipe the remote); diffs and confirms before overwriting.
- `--force` skips prompts for non-interactive use.
- SSM version history (last 100) makes a bad push recoverable.

## Fixes beyond the original design
- **Round-trip fidelity:** both `aws … --output text` and `jq -r` append an extra trailing newline → a permanent phantom diff that would also break `push`'s "already up to date" check. The value is normalized to exactly one trailing newline at every materialize/compare point, so round-trips are byte-identical.
- **EXIT-trap cleanup** now always returns 0 so `make` doesn't surface a false `Error 1` on the no-temp-file (`diff`/`push`) path.
- `set -e` is handled around `diff` (exit 1 on difference) and `ParameterNotFound` so friendly messages aren't skipped.

## Verification (all pass)
- SSM `/recruiter-dashboard/tfvars` exists as a **SecureString** in `us-east-1`; version history intact; remote holds the original value.
- Round-trip byte-identical (1298 → 1298 bytes).
- Empty-file push refused; drift detected → pushed → recoverable via history.
- All three `make` targets exit 0.
- **No `.tf`, IAM, or CI/CD changes**; `terraform.tfvars` and `.bak` remain git-ignored.

## Notes
- The SSM parameter was seeded from the maintainer's local file as part of this work (created in account `954282926070`, `us-east-1`).
- `terraform plan` (issue verification step 5) was **not** run here — it hits the live S3 backend; the tfvars content is unchanged so it's low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)