### PR TITLE
fix(infra): tfvars.sh CRLF phantom diff, drift exit code, and non-destructive backups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ terraform -chdir=infra/recruiter-dashboard fmt -check -recursive
 terraform -chdir=infra/recruiter-dashboard plan
 ```
 
-`infra/recruiter-dashboard/terraform.tfvars` is git-ignored; its source of truth is the SSM SecureString `/recruiter-dashboard/tfvars` (us-east-1), synced via `scripts/tfvars.sh`. Run `make tf-vars-pull` before `plan`/`apply`, `make tf-vars-push` after editing the file, `make tf-vars-diff` to check drift (exits non-zero when drift exists, so it can gate a script or CI check). Add `TFVARS_ARGS=--force` to skip the confirmation prompt non-interactively.
+`infra/recruiter-dashboard/terraform.tfvars` is git-ignored; its source of truth is the SSM SecureString `/recruiter-dashboard/tfvars` (us-east-1), synced via `scripts/tfvars.sh`. Run `make tf-vars-pull` before `plan`/`apply`, `make tf-vars-push` after editing the file, `make tf-vars-diff` to check drift (exit `1` means drift, so it can gate a script or CI check; `3` means nothing to compare — parameter not seeded or no local file — and `4` an AWS/`diff` failure). Add `TFVARS_ARGS=--force` to skip the confirmation prompt non-interactively.
 
 ### All-in-one CI check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ terraform -chdir=infra/recruiter-dashboard fmt -check -recursive
 terraform -chdir=infra/recruiter-dashboard plan
 ```
 
-`infra/recruiter-dashboard/terraform.tfvars` is git-ignored; its source of truth is the SSM SecureString `/recruiter-dashboard/tfvars` (us-east-1), synced via `scripts/tfvars.sh`. Run `make tf-vars-pull` before `plan`/`apply`, `make tf-vars-push` after editing the file, `make tf-vars-diff` to check drift.
+`infra/recruiter-dashboard/terraform.tfvars` is git-ignored; its source of truth is the SSM SecureString `/recruiter-dashboard/tfvars` (us-east-1), synced via `scripts/tfvars.sh`. Run `make tf-vars-pull` before `plan`/`apply`, `make tf-vars-push` after editing the file, `make tf-vars-diff` to check drift (exits non-zero when drift exists, so it can gate a script or CI check).
 
 ### All-in-one CI check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ terraform -chdir=infra/recruiter-dashboard fmt -check -recursive
 terraform -chdir=infra/recruiter-dashboard plan
 ```
 
-`infra/recruiter-dashboard/terraform.tfvars` is git-ignored; its source of truth is the SSM SecureString `/recruiter-dashboard/tfvars` (us-east-1), synced via `scripts/tfvars.sh`. Run `make tf-vars-pull` before `plan`/`apply`, `make tf-vars-push` after editing the file, `make tf-vars-diff` to check drift (exits non-zero when drift exists, so it can gate a script or CI check).
+`infra/recruiter-dashboard/terraform.tfvars` is git-ignored; its source of truth is the SSM SecureString `/recruiter-dashboard/tfvars` (us-east-1), synced via `scripts/tfvars.sh`. Run `make tf-vars-pull` before `plan`/`apply`, `make tf-vars-push` after editing the file, `make tf-vars-diff` to check drift (exits non-zero when drift exists, so it can gate a script or CI check). Add `TFVARS_ARGS=--force` to skip the confirmation prompt non-interactively.
 
 ### All-in-one CI check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ All commands run from `infra/recruiter-dashboard/`:
 
 - **Before `plan`/`apply`:** `make tf-vars-pull` (fetch latest from SSM)
 - **After editing the file:** `make tf-vars-push` (back up to SSM as a new version)
-- **Check for drift:** `make tf-vars-diff` (exits non-zero when drift exists, so it can gate a script or CI check — a `make ... Error 1` here is the drift signal, not a failure)
+- **Check for drift:** `make tf-vars-diff` (exit `1` means drift, so it can gate a script or CI check — a `make ... Error 1` here is the drift signal, not a failure; `3` means there was nothing to compare and `4` that the AWS call or `diff` failed)
 
 All three targets prompt before overwriting anything. For non-interactive use, skip the prompt with `make tf-vars-push TFVARS_ARGS=--force`. `pull` writes a timestamped `terraform.tfvars.<UTC>.bak` next to the file before overwriting it; these are git-ignored and are never cleaned up automatically.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ All commands run from `infra/recruiter-dashboard/`:
 
 - **Before `plan`/`apply`:** `make tf-vars-pull` (fetch latest from SSM)
 - **After editing the file:** `make tf-vars-push` (back up to SSM as a new version)
-- **Check for drift:** `make tf-vars-diff`
+- **Check for drift:** `make tf-vars-diff` (exits non-zero when drift exists, so it can gate a script or CI check — a `make ... Error 1` here is the drift signal, not a failure)
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ All commands run from `infra/recruiter-dashboard/`:
 - **After editing the file:** `make tf-vars-push` (back up to SSM as a new version)
 - **Check for drift:** `make tf-vars-diff` (exits non-zero when drift exists, so it can gate a script or CI check — a `make ... Error 1` here is the drift signal, not a failure)
 
+All three targets prompt before overwriting anything. For non-interactive use, skip the prompt with `make tf-vars-push TFVARS_ARGS=--force`. `pull` writes a timestamped `terraform.tfvars.<UTC>.bak` next to the file before overwriting it; these are git-ignored and are never cleaned up automatically.
+
 ## Architecture
 
 ### Frontend

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,9 @@ tf-plan:
 # the confirmation prompt for non-interactive use:
 #   make tf-vars-push TFVARS_ARGS=--force
 # tf-vars-diff exits non-zero when drift exists so it can gate a script or CI
-# check; the resulting `Error 1` is the drift signal, not a malfunction.
+# check; the resulting `Error 1` is the drift signal, not a malfunction. Only 1
+# means drift — 3 means there was nothing to compare (parameter not seeded, or
+# no local terraform.tfvars) and 4 means the AWS call or diff itself failed.
 TFVARS_ARGS ?=
 
 tf-vars-pull:

--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,22 @@ tf-plan:
 	@terraform -chdir=$(INFRA_DIR) plan
 
 # terraform.tfvars <-> SSM sync (SSM is the durable source of truth; the file is git-ignored)
+#
+# TFVARS_ARGS passes flags through to the script — chiefly --force, which skips
+# the confirmation prompt for non-interactive use:
+#   make tf-vars-push TFVARS_ARGS=--force
+# tf-vars-diff exits non-zero when drift exists so it can gate a script or CI
+# check; the resulting `Error 1` is the drift signal, not a malfunction.
+TFVARS_ARGS ?=
+
 tf-vars-pull:
-	@$(INFRA_DIR)/scripts/tfvars.sh pull
+	@$(INFRA_DIR)/scripts/tfvars.sh pull $(TFVARS_ARGS)
 
 tf-vars-push:
-	@$(INFRA_DIR)/scripts/tfvars.sh push
+	@$(INFRA_DIR)/scripts/tfvars.sh push $(TFVARS_ARGS)
 
 tf-vars-diff:
-	@$(INFRA_DIR)/scripts/tfvars.sh diff
+	@$(INFRA_DIR)/scripts/tfvars.sh diff $(TFVARS_ARGS)
 
 # Clean build artifacts
 clean:

--- a/infra/recruiter-dashboard/.gitignore
+++ b/infra/recruiter-dashboard/.gitignore
@@ -5,7 +5,9 @@
 
 # Variables with secrets
 terraform.tfvars
-# Local backup written by scripts/tfvars.sh pull
+# Local backups written by scripts/tfvars.sh pull (timestamped; plain .bak is
+# the legacy name written before backups were made per-pull)
+terraform.tfvars.*.bak
 terraform.tfvars.bak
 
 # Crash logs

--- a/infra/recruiter-dashboard/AGENTS.md
+++ b/infra/recruiter-dashboard/AGENTS.md
@@ -30,7 +30,12 @@ make -C ../.. tf-vars-diff   # check drift vs SSM (non-zero exit == drift)
 
 ## terraform.tfvars (sourced from SSM)
 
-`terraform.tfvars` is git-ignored; its durable, versioned source of truth is the SSM SecureString parameter `/recruiter-dashboard/tfvars` (us-east-1). `scripts/tfvars.sh` mirrors the file verbatim to/from SSM (`pull`/`push`/`diff`) — Terraform code is unaware of it. Run `make tf-vars-pull` before `plan`/`apply` and `make tf-vars-push` after editing the file.
+`terraform.tfvars` is git-ignored; its durable, versioned source of truth is the SSM SecureString parameter `/recruiter-dashboard/tfvars` (us-east-1). `scripts/tfvars.sh` mirrors the file to/from SSM (`pull`/`push`/`diff`) — Terraform code is unaware of it. Run `make tf-vars-pull` before `plan`/`apply` and `make tf-vars-push` after editing the file.
+
+- `diff` exits 0 for no drift, 1 for drift, 2 for usage errors — so it can gate a script or CI check.
+- Push normalizes the file: CRs are stripped and trailing blank lines collapse to one newline (SSM stores LF only, and this keeps round-trips byte-stable).
+- `pull` writes a timestamped `terraform.tfvars.<UTC>.bak` before overwriting; git-ignored, never auto-pruned.
+- `TFVARS_ARGS=--force` skips confirmation prompts, e.g. `make tf-vars-push TFVARS_ARGS=--force`.
 
 ## Email Parsing Pipeline
 

--- a/infra/recruiter-dashboard/AGENTS.md
+++ b/infra/recruiter-dashboard/AGENTS.md
@@ -25,7 +25,7 @@ terraform plan
 # terraform.tfvars sync (SSM is the source of truth; the file is git-ignored)
 make -C ../.. tf-vars-pull   # before plan/apply
 make -C ../.. tf-vars-push   # after editing terraform.tfvars
-make -C ../.. tf-vars-diff   # check drift vs SSM
+make -C ../.. tf-vars-diff   # check drift vs SSM (non-zero exit == drift)
 ```
 
 ## terraform.tfvars (sourced from SSM)

--- a/infra/recruiter-dashboard/AGENTS.md
+++ b/infra/recruiter-dashboard/AGENTS.md
@@ -25,15 +25,16 @@ terraform plan
 # terraform.tfvars sync (SSM is the source of truth; the file is git-ignored)
 make -C ../.. tf-vars-pull   # before plan/apply
 make -C ../.. tf-vars-push   # after editing terraform.tfvars
-make -C ../.. tf-vars-diff   # check drift vs SSM (non-zero exit == drift)
+make -C ../.. tf-vars-diff   # check drift vs SSM (exit 1 == drift)
 ```
 
 ## terraform.tfvars (sourced from SSM)
 
 `terraform.tfvars` is git-ignored; its durable, versioned source of truth is the SSM SecureString parameter `/recruiter-dashboard/tfvars` (us-east-1). `scripts/tfvars.sh` mirrors the file to/from SSM (`pull`/`push`/`diff`) — Terraform code is unaware of it. Run `make tf-vars-pull` before `plan`/`apply` and `make tf-vars-push` after editing the file.
 
-- `diff` exits 0 for no drift, 1 for drift, 2 for usage errors — so it can gate a script or CI check.
+- `diff` exit codes — so it can gate a script or CI check: `0` no drift, `1` drift, `2` usage error, `3` nothing to compare (parameter not seeded, or no local file), `4` AWS call or `diff` itself failed. Only `1` means drift; `3` and `4` need different remedies.
 - Push normalizes the file: CRs are stripped and trailing blank lines collapse to one newline (SSM stores LF only, and this keeps round-trips byte-stable).
+- All three subcommands compare the *canonical* form, so a CRLF file is not perpetual drift. `pull` leaves a CRLF file's bytes on disk when it matches canonically rather than rewriting it.
 - `pull` writes a timestamped `terraform.tfvars.<UTC>.bak` before overwriting; git-ignored, never auto-pruned.
 - `TFVARS_ARGS=--force` skips confirmation prompts, e.g. `make tf-vars-push TFVARS_ARGS=--force`.
 

--- a/infra/recruiter-dashboard/CLAUDE.md
+++ b/infra/recruiter-dashboard/CLAUDE.md
@@ -22,7 +22,7 @@ terraform fmt -check -recursive
 # terraform.tfvars sync (SSM is the source of truth; the file is git-ignored)
 make -C ../.. tf-vars-pull   # before plan/apply
 make -C ../.. tf-vars-push   # after editing terraform.tfvars
-make -C ../.. tf-vars-diff   # check drift vs SSM
+make -C ../.. tf-vars-diff   # check drift vs SSM (non-zero exit == drift)
 ```
 
 ## terraform.tfvars (sourced from SSM)

--- a/infra/recruiter-dashboard/CLAUDE.md
+++ b/infra/recruiter-dashboard/CLAUDE.md
@@ -22,15 +22,16 @@ terraform fmt -check -recursive
 # terraform.tfvars sync (SSM is the source of truth; the file is git-ignored)
 make -C ../.. tf-vars-pull   # before plan/apply
 make -C ../.. tf-vars-push   # after editing terraform.tfvars
-make -C ../.. tf-vars-diff   # check drift vs SSM (non-zero exit == drift)
+make -C ../.. tf-vars-diff   # check drift vs SSM (exit 1 == drift)
 ```
 
 ## terraform.tfvars (sourced from SSM)
 
 `terraform.tfvars` is git-ignored; its durable, versioned source of truth is the SSM SecureString parameter `/recruiter-dashboard/tfvars` (us-east-1). `scripts/tfvars.sh` mirrors the file to/from SSM (`pull`/`push`/`diff`) — Terraform code is unaware of it. Run `make tf-vars-pull` before `plan`/`apply` and `make tf-vars-push` after editing the file.
 
-- `diff` exits 0 for no drift, 1 for drift, 2 for usage errors — so it can gate a script or CI check.
+- `diff` exit codes — so it can gate a script or CI check: `0` no drift, `1` drift, `2` usage error, `3` nothing to compare (parameter not seeded, or no local file), `4` AWS call or `diff` itself failed. Only `1` means drift; `3` and `4` need different remedies.
 - Push normalizes the file: CRs are stripped and trailing blank lines collapse to one newline (SSM stores LF only, and this keeps round-trips byte-stable).
+- All three subcommands compare the *canonical* form, so a CRLF file is not perpetual drift. `pull` leaves a CRLF file's bytes on disk when it matches canonically rather than rewriting it.
 - `pull` writes a timestamped `terraform.tfvars.<UTC>.bak` before overwriting; git-ignored, never auto-pruned.
 - `TFVARS_ARGS=--force` skips confirmation prompts, e.g. `make tf-vars-push TFVARS_ARGS=--force`.
 

--- a/infra/recruiter-dashboard/CLAUDE.md
+++ b/infra/recruiter-dashboard/CLAUDE.md
@@ -27,7 +27,12 @@ make -C ../.. tf-vars-diff   # check drift vs SSM (non-zero exit == drift)
 
 ## terraform.tfvars (sourced from SSM)
 
-`terraform.tfvars` is git-ignored; its durable, versioned source of truth is the SSM SecureString parameter `/recruiter-dashboard/tfvars` (us-east-1). `scripts/tfvars.sh` mirrors the file verbatim to/from SSM (`pull`/`push`/`diff`) — Terraform code is unaware of it. Run `make tf-vars-pull` before `plan`/`apply` and `make tf-vars-push` after editing the file.
+`terraform.tfvars` is git-ignored; its durable, versioned source of truth is the SSM SecureString parameter `/recruiter-dashboard/tfvars` (us-east-1). `scripts/tfvars.sh` mirrors the file to/from SSM (`pull`/`push`/`diff`) — Terraform code is unaware of it. Run `make tf-vars-pull` before `plan`/`apply` and `make tf-vars-push` after editing the file.
+
+- `diff` exits 0 for no drift, 1 for drift, 2 for usage errors — so it can gate a script or CI check.
+- Push normalizes the file: CRs are stripped and trailing blank lines collapse to one newline (SSM stores LF only, and this keeps round-trips byte-stable).
+- `pull` writes a timestamped `terraform.tfvars.<UTC>.bak` before overwriting; git-ignored, never auto-pruned.
+- `TFVARS_ARGS=--force` skips confirmation prompts, e.g. `make tf-vars-push TFVARS_ARGS=--force`.
 
 ## Lambda Functions
 

--- a/infra/recruiter-dashboard/scripts/tfvars.sh
+++ b/infra/recruiter-dashboard/scripts/tfvars.sh
@@ -14,7 +14,13 @@
 #   0  success — for `diff`, specifically means "no drift"
 #   1  drift detected (`diff`), user aborted, or a refused/guarded operation
 #   2  usage error
-#   *  other non-zero: AWS CLI or plumbing failure
+#   3  cannot compare — SSM parameter not seeded, or no local terraform.tfvars
+#   4  operational failure — AWS CLI, or `diff` itself failed
+#
+# 1 means *only* "the two sides differ" (or the user said no). A gate such as
+# `make tf-vars-diff || remediate` must be able to tell real drift apart from a
+# fresh checkout that has not pulled yet (3) and from expired credentials (4),
+# since those three need opposite remedies.
 #
 # Region is hardcoded so the script never depends on AWS_DEFAULT_REGION, but it
 # still respects AWS_PROFILE for credential selection.
@@ -44,7 +50,9 @@ usage() {
 # re-add exactly one trailing newline via `emit_remote` when writing/comparing,
 # so round-trips match the canonical terraform.tfvars form (one trailing \n).
 #
-# Returns 10 if the parameter does not exist yet; any other non-zero on error.
+# Returns 10 if the parameter does not exist yet (an internal sentinel callers
+# translate into their own message); 4 for any other AWS CLI failure, so a
+# credential or network error never reaches a caller as the drift code 1.
 read_remote() {
   local out
   if ! out="$(aws ssm get-parameter \
@@ -57,7 +65,7 @@ read_remote() {
       return 10
     fi
     echo "$out" >&2
-    return 1
+    return 4
   fi
   printf '%s' "$out"
 }
@@ -80,11 +88,13 @@ emit_remote() { printf '%s\n' "$1"; }
 #      phantom diff too.
 canon_local() { emit_remote "$(tr -d '\r' <"$TFVARS")"; }
 
-# Warn when canon_local will silently alter the file's line endings, so the
-# normalization is visible rather than surprising.
+# Warn when canon_local's normalization is in play, so it is visible rather than
+# surprising. Worded to hold for all three subcommands: push strips the CRs on
+# upload, diff and pull only ignore them when comparing (pull leaves the bytes
+# on disk untouched — see cmd_pull).
 warn_if_crlf() {
   if LC_ALL=C grep -q $'\r' "$TFVARS" 2>/dev/null; then
-    echo "Note: terraform.tfvars contains CR characters; they are stripped (SSM stores LF only)." >&2
+    echo "Note: terraform.tfvars contains CR characters; SSM stores LF only, so they are ignored when comparing and stripped on push." >&2
   fi
 }
 
@@ -128,7 +138,7 @@ cmd_pull() {
   set -e
   if [[ $rc -eq 10 ]]; then
     echo "Parameter $PARAM_NAME not seeded yet — run 'make tf-vars-push' first." >&2
-    exit 1
+    exit 3
   elif [[ $rc -ne 0 ]]; then
     exit $rc
   fi
@@ -137,12 +147,20 @@ cmd_pull() {
   emit_remote "$remote" >"$TMPFILE"
 
   if [[ -f "$TFVARS" ]]; then
-    if diff -u "$TFVARS" "$TMPFILE" >/dev/null 2>&1; then
+    # Compare the canonical local form (see canon_local), not the raw file. A
+    # CRLF or trailing-blank-line difference is normalized away by push, so it
+    # is not a real difference — and comparing raw would make a Windows-edited
+    # file prompt and write a fresh timestamped backup on *every* pull, forever,
+    # accumulating silently under TFVARS_ARGS=--force. The cost is that such a
+    # file keeps its CR bytes on disk instead of being rewritten; Terraform
+    # reads it identically either way, and push still uploads LF only.
+    warn_if_crlf
+    if canon_local | diff -u - "$TMPFILE" >/dev/null 2>&1; then
       echo "Local terraform.tfvars already matches SSM. Nothing to do."
       return 0
     fi
     echo "Local terraform.tfvars differs from SSM:"
-    diff -u "$TFVARS" "$TMPFILE" || true
+    canon_local | diff -u --label "local:terraform.tfvars" --label "ssm:$PARAM_NAME" - "$TMPFILE" || true
     echo
     if ! confirm "Overwrite local file? (a timestamped backup will be written alongside it)"; then
       echo "Aborted." >&2
@@ -219,16 +237,19 @@ cmd_diff() {
   rc=$?
   set -e
 
+  # Both "not seeded" and "no local file" mean there is nothing to compare, not
+  # that the two sides differ — exit 3, so a gate does not mistake a fresh
+  # checkout for drift and try to remediate it as one.
   if [[ $rc -eq 10 ]]; then
     echo "Parameter $PARAM_NAME not seeded yet — run 'make tf-vars-push' first." >&2
-    exit 1
+    exit 3
   elif [[ $rc -ne 0 ]]; then
     exit $rc
   fi
 
   if [[ ! -f "$TFVARS" ]]; then
     echo "No local terraform.tfvars — run 'make tf-vars-pull' to fetch it." >&2
-    exit 1
+    exit 3
   fi
 
   # Compare the canonical local form, not the raw file: push uploads the
@@ -238,14 +259,29 @@ cmd_diff() {
   TMPFILE="$(mktemp)"
   canon_local >"$TMPFILE"
 
-  if emit_remote "$remote" | diff -u - "$TMPFILE" >/dev/null 2>&1; then
+  # Run diff once and branch on its exact status. `if diff ...` would collapse
+  # status 2 (diff itself failed — unreadable input, etc.) into the drift path,
+  # reporting a plumbing failure as drift to whatever is gating on this.
+  local out status
+  set +e
+  out="$(emit_remote "$remote" | diff -u --label "ssm:$PARAM_NAME" --label "local:terraform.tfvars" - "$TMPFILE" 2>&1)"
+  status=$?
+  set -e
+
+  if [[ $status -eq 0 ]]; then
     echo "No drift — local terraform.tfvars matches SSM."
     return 0
+  elif [[ $status -ne 1 ]]; then
+    echo "Comparison failed (diff exited $status):" >&2
+    printf '%s\n' "$out" >&2
+    exit 4
   fi
+
   echo "Drift detected (remote <-> local):"
-  emit_remote "$remote" | diff -u --label "ssm:$PARAM_NAME" --label "local:terraform.tfvars" - "$TMPFILE" || true
-  # Exit non-zero so `make tf-vars-diff` is usable as a check in scripts, CI, or
-  # a pre-apply guard. A `make ... Error 1` here is the intended drift signal.
+  printf '%s\n' "$out"
+  # Exit 1 so `make tf-vars-diff` is usable as a check in scripts, CI, or a
+  # pre-apply guard. A `make ... Error 1` here is the intended drift signal;
+  # 3 and 4 mean the comparison never happened (see the header).
   exit 1
 }
 

--- a/infra/recruiter-dashboard/scripts/tfvars.sh
+++ b/infra/recruiter-dashboard/scripts/tfvars.sh
@@ -10,6 +10,12 @@
 #   push   local file -> SSM (refuses empty/missing local; confirms before overwrite)
 #   diff   show local-vs-remote differences; never writes
 #
+# Exit codes:
+#   0  success — for `diff`, specifically means "no drift"
+#   1  drift detected (`diff`), user aborted, or a refused/guarded operation
+#   2  usage error
+#   *  other non-zero: AWS CLI or plumbing failure
+#
 # Region is hardcoded so the script never depends on AWS_DEFAULT_REGION, but it
 # still respects AWS_PROFILE for credential selection.
 set -euo pipefail
@@ -59,6 +65,29 @@ read_remote() {
 
 # Print a captured remote value normalized to exactly one trailing newline.
 emit_remote() { printf '%s\n' "$1"; }
+
+# Print the local file in canonical form: LF-only line endings, exactly one
+# trailing newline. This is the form `push` uploads and the form every
+# comparison must use.
+#
+# Two normalizations, both required for a stable round-trip:
+#   1. CR stripping — the AWS CLI's file:// reader converts CRLF to LF on
+#      upload, so a CR can never survive to the remote. Comparing the raw local
+#      file against the remote would therefore report drift forever, and push
+#      could never reach "Already up to date".
+#   2. Trailing newlines — command substitution strips *all* of them and
+#      emit_remote re-adds exactly one, so trailing blank lines are collapsed.
+#      A file saved without a trailing newline would otherwise be a permanent
+#      phantom diff too.
+canon_local() { emit_remote "$(tr -d '\r' <"$TFVARS")"; }
+
+# Warn when canon_local will silently alter the file's line endings, so the
+# normalization is visible rather than surprising.
+warn_if_crlf() {
+  if LC_ALL=C grep -q $'\r' "$TFVARS" 2>/dev/null; then
+    echo "Note: terraform.tfvars contains CR characters; they are stripped (SSM stores LF only)." >&2
+  fi
+}
 
 confirm() {
   # $1 = prompt. Honors a global FORCE flag for non-interactive use.
@@ -112,16 +141,11 @@ cmd_push() {
     exit 1
   fi
 
-  # Canonicalize the local file to the same one-trailing-newline form that
-  # emit_remote produces, so the comparison below and the uploaded value match
-  # the remote round-trip exactly. Without this, a local file saved without a
-  # trailing newline would create a permanent phantom diff that "Already up to
-  # date" could never satisfy. Command substitution strips trailing newlines;
-  # emit_remote re-adds exactly one.
-  local local_canon
-  local_canon="$(cat "$TFVARS")"
+  # Upload the canonical form (see canon_local), so what is compared below is
+  # byte-for-byte what SSM will store and what a later pull will write back.
+  warn_if_crlf
   TMPFILE="$(mktemp)"
-  emit_remote "$local_canon" >"$TMPFILE"
+  canon_local >"$TMPFILE"
 
   local remote rc
   set +e
@@ -177,12 +201,22 @@ cmd_diff() {
     exit 1
   fi
 
-  if emit_remote "$remote" | diff -u - "$TFVARS" >/dev/null 2>&1; then
+  # Compare the canonical local form, not the raw file: push uploads the
+  # canonical form, so raw-file differences that push would normalize away are
+  # not drift and must not be reported as such.
+  warn_if_crlf
+  TMPFILE="$(mktemp)"
+  canon_local >"$TMPFILE"
+
+  if emit_remote "$remote" | diff -u - "$TMPFILE" >/dev/null 2>&1; then
     echo "No drift — local terraform.tfvars matches SSM."
     return 0
   fi
   echo "Drift detected (remote <-> local):"
-  emit_remote "$remote" | diff -u --label "ssm:$PARAM_NAME" --label "local:terraform.tfvars" - "$TFVARS" || true
+  emit_remote "$remote" | diff -u --label "ssm:$PARAM_NAME" --label "local:terraform.tfvars" - "$TMPFILE" || true
+  # Exit non-zero so `make tf-vars-diff` is usable as a check in scripts, CI, or
+  # a pre-apply guard. A `make ... Error 1` here is the intended drift signal.
+  exit 1
 }
 
 main() {

--- a/infra/recruiter-dashboard/scripts/tfvars.sh
+++ b/infra/recruiter-dashboard/scripts/tfvars.sh
@@ -28,7 +28,6 @@ REGION="us-east-1"
 # works regardless of the caller's working directory.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TFVARS="$(cd "$SCRIPT_DIR/.." && pwd)/terraform.tfvars"
-BACKUP="$TFVARS.bak"
 
 # Temp file cleaned up on exit (set by pull). Initialized empty for `set -u`.
 TMPFILE=""
@@ -89,6 +88,28 @@ warn_if_crlf() {
   fi
 }
 
+# Echo a unique, timestamped backup path for the local file.
+#
+# Backups are per-pull rather than a single fixed terraform.tfvars.bak slot: two
+# pulls in a row would otherwise overwrite the first backup and silently destroy
+# local edits that were never pushed. SSM version history is the primary
+# recovery path; these cover local-only state it never saw. They are git-ignored
+# and never pruned automatically — delete them by hand when you're done.
+backup_path() {
+  local stamp base candidate n
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  base="$TFVARS.$stamp"
+  candidate="$base.bak"
+  # Two pulls within the same second would collide; disambiguate rather than
+  # clobber, since not clobbering is the entire point of this function.
+  n=1
+  while [[ -e "$candidate" ]]; do
+    candidate="$base-$n.bak"
+    n=$((n + 1))
+  done
+  printf '%s' "$candidate"
+}
+
 confirm() {
   # $1 = prompt. Honors a global FORCE flag for non-interactive use.
   if [[ "${FORCE:-0}" == "1" ]]; then
@@ -123,12 +144,14 @@ cmd_pull() {
     echo "Local terraform.tfvars differs from SSM:"
     diff -u "$TFVARS" "$TMPFILE" || true
     echo
-    if ! confirm "Overwrite local file? (a backup will be written to terraform.tfvars.bak)"; then
+    if ! confirm "Overwrite local file? (a timestamped backup will be written alongside it)"; then
       echo "Aborted." >&2
       exit 1
     fi
-    cp "$TFVARS" "$BACKUP"
-    echo "Backed up current local file to terraform.tfvars.bak"
+    local backup
+    backup="$(backup_path)"
+    cp "$TFVARS" "$backup"
+    echo "Backed up current local file to $(basename "$backup")"
   fi
 
   cp "$TMPFILE" "$TFVARS"
@@ -143,6 +166,9 @@ cmd_push() {
 
   # Upload the canonical form (see canon_local), so what is compared below is
   # byte-for-byte what SSM will store and what a later pull will write back.
+  # Note this normalizes the file: CRs are stripped and any trailing blank lines
+  # collapse to a single trailing newline. Both are required for a stable
+  # round-trip, so the uploaded value may differ from the raw file on disk.
   warn_if_crlf
   TMPFILE="$(mktemp)"
   canon_local >"$TMPFILE"
@@ -172,6 +198,10 @@ cmd_push() {
     exit 1
   fi
 
+  # --value file:// (not an inline value) keeps the secret out of argv.
+  # Intelligent-Tiering auto-promotes to Advanced past 4096 bytes, which costs
+  # $0.05/parameter/month; under that it stays on the free Standard tier. The
+  # file is ~1.3 KB today, so this is only a concern if tfvars grows a lot.
   aws ssm put-parameter \
     --name "$PARAM_NAME" \
     --type SecureString \


### PR DESCRIPTION
Closes #107.

Fixes all six findings from the post-merge review of #106. Two commits: P1 defects (`48d7378`), then P2 robustness/ergonomics (`d1e183d`). No `.tf`, IAM, or CI/CD changes.

## P1 — functional defects

### 1. CRLF caused a permanent phantom diff

The AWS CLI's `file://` reader converts CRLF to LF when reading `terraform.tfvars`, so a CR never reaches SSM. `push` and `diff` compared the *raw* local file against the remote, so the two could never agree:

```console
$ ./scripts/tfvars.sh push --force
Pushed terraform.tfvars -> …
$ ./scripts/tfvars.sh diff          # immediately after a successful push
Drift detected (remote <-> local):
-crlf = "z"
+crlf = "z"
```

`push` could never print "Already up to date" and re-prompted forever; `make tf-vars-diff` reported drift permanently. Same bug class #106 fixed for trailing newlines — the normalization just wasn't applied to `\r`.

The root cause was that push and diff canonicalized *differently*, so the fix extracts the existing push-side logic into one `canon_local` helper, adds CR stripping, and uses it on both paths. `warn_if_crlf` keeps the normalization visible rather than silent.

### 2. `diff` exited 0 even on drift

`cmd_diff` ended in `|| true`, so `make tf-vars-diff` was human-readable output only — it couldn't gate a script, CI check, or pre-`apply` guard. Now exits 1 on drift, with the full contract documented in the script header (see the review round below, which widened it to 0/1/2/3/4).

⚠️ **Intentional behavior change:** `make tf-vars-diff` now surfaces `make: *** [tf-vars-diff] Error 1` when drift exists. That's the signal, not a malfunction — there's a comment in the script and Makefile saying so.

## P2 — robustness and ergonomics

**3. Backups were destructive.** `pull` wrote a fixed `terraform.tfvars.bak`, so two pulls in a row destroyed the first — precisely the local-only edits it was meant to protect. Now writes a timestamped `terraform.tfvars.<UTC>.bak` per pull, with a counter suffix for same-second collisions. `.gitignore` widened to `terraform.tfvars.*.bak`. Not auto-pruned: deleting user backups to fix a lost-backup bug seemed like the wrong trade.

**4. `--force` unreachable through `make`.** The targets hardcoded each subcommand, so non-interactive use meant bypassing `make` entirely. Added a `TFVARS_ARGS` pass-through: `make tf-vars-push TFVARS_ARGS=--force`.

**5 & 6. Undocumented behavior.** Comments on the `--tier` line (Intelligent-Tiering auto-promotes to the paid Advanced tier past 4 KB; the file is ~1.3 KB today) and on `cmd_push` (trailing blank lines collapse to a single newline).

Docs updated across all four `CLAUDE.md` / `AGENTS.md` files.

## Review round 2 (`e3122ee`)

Two review findings, both about the gate this PR advertises.

### 7. `cmd_pull` compared the raw file, spamming backups

Originally defended as deliberate (see the struck-through note below), but the consequence outweighed the principle. `canon_local` was applied to `push` and `diff` but not `pull`, so a CRLF-edited file read as "no drift" to `diff` yet "differs" to `pull` — prompting and writing a fresh timestamped `.bak` on **every** pull, never pruned, one per run under `TFVARS_ARGS=--force`.

Pull now compares the canonical form too. The trade: a CRLF file that matches canonically keeps its CR bytes on disk instead of being rewritten. Terraform reads it identically and `push` still uploads LF only, so byte-identity with the remote is given up only for the line endings that never round-trip anyway.

### 8. Exit 1 was overloaded four ways

`cmd_diff` exited 1 for drift — but also for an unseeded parameter, a missing local file, and (via `read_remote`) any AWS CLI failure. `make tf-vars-diff || remediate` therefore flagged a fresh checkout and expired credentials as drift, three cases needing opposite remedies. `cmd_diff` also used `if diff ...`, folding `diff`'s own status 2 (comparison failure) into the drift path.

New contract, documented in the script header, Makefile, and all four docs:

| Code | Meaning |
|---|---|
| 0 | no drift |
| 1 | **drift** (or user aborted) |
| 2 | usage error |
| 3 | nothing to compare — parameter not seeded, or no local file |
| 4 | operational failure — AWS CLI, or `diff` itself failed |

`cmd_diff` now branches on `diff`'s exact status rather than truthiness.

## Verification

Run against a throwaway SSM parameter with `PARAM_NAME` repointed, deleted afterward. The real `/recruiter-dashboard/tfvars` is **untouched at v3** and the local file is unmodified at 1298 bytes.

| Check | Result |
|---|---|
| CRLF file: push → diff | no drift, exit 0 |
| CRLF file: second push | "Already up to date", no prompt |
| Drift present → `diff` | exit 1 |
| No drift → `diff` | exit 0 |
| Unseeded parameter → `diff` / `pull` | exit 3 |
| No local file → `diff` | exit 3 |
| Expired credentials → `diff` / `pull` | exit 4 |
| CRLF file: 4 consecutive `pull --force` | 0 backups, file untouched |
| 5 consecutive pulls | 5 distinct recoverable backups, none clobbered |
| Backup names vs `.gitignore` | all ignored (`git check-ignore`, both timestamped and `-N` forms) |
| `TFVARS_ARGS=--force` | reaches the script (`make -n`) |
| Byte-identical round trip — tabs, Unicode, leading dashes, `$`/`%`, backslashes, interior blank lines | preserved |
| No-trailing-newline file (the #106 fix) | still converges |
| Empty / missing local file push | both refused, exit 1 |
| No-TTY `push` | aborts, exit 1, remote untouched |
| Usage errors | exit 2 |
| Run from arbitrary cwd | correct |
| Secrets via `--value file://` (never `argv`) | unchanged |
| `make ci` | passes |

## Reviewer notes

- ~~**`cmd_pull` still compares the raw file, not the canonical form** — deliberate. Pull's contract is "make local byte-identical to remote," so a CRLF local file *should* register as different and get normalized on overwrite.~~ **Reversed in `e3122ee`** — see finding 7. The principle was right but the cost was a backup written on every pull, forever; pull now compares canonically.
- Exit codes 3 and 4 are new in `e3122ee`. Anything already scripted against "non-zero means drift" needs to test for `1` specifically.
- Backups accumulate without pruning. They're git-ignored and Terraform doesn't auto-load `*.bak`, so they're inert — but they do need occasional manual cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

