### PR TITLE
fix(frontend): proxy API calls in dev so /dashboard works on localhost

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,6 +7,8 @@
 VITE_API_BASE_URL=/dashboard-api
 
 # The resume-request API. NOTE: submitting the form locally still hits the real
-# production /requests endpoint and creates a real request — point this at a
-# stub in .env.local if you need to exercise the form without doing that.
+# production /requests endpoint and creates a real request. To exercise the form
+# without that, override this in a git-ignored `.env.development.local` — NOT
+# `.env.local`, which Vite ranks below this mode-specific file and which
+# therefore cannot override anything set here.
 VITE_REQUESTS_API_BASE_URL=/requests-api

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,12 @@
+# Loaded by `npm run dev` only (mode=development); production builds and Vitest
+# (mode=test) fall back to the real API origin in src/lib/api.js.
+#
+# Routes dashboard API calls through the Vite dev-server proxy in vite.config.js
+# so they are same-origin and skip CORS, which the API only grants to
+# https://sh3r4rd.com.
+VITE_API_BASE_URL=/dashboard-api
+
+# The resume-request API. NOTE: submitting the form locally still hits the real
+# production /requests endpoint and creates a real request — point this at a
+# stub in .env.local if you need to exercise the form without doing that.
+VITE_REQUESTS_API_BASE_URL=/requests-api

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,9 @@ Personal portfolio website (sh3r4rd.com) built with React, Tailwind CSS, and Vit
 | `API_BASE` | `VITE_API_BASE_URL` | `https://dashboard-api.sh3r4rd.com` | `/dashboard-api` |
 | `REQUESTS_API_BASE` | `VITE_REQUESTS_API_BASE_URL` | `https://api.sh3r4rd.com` | `/requests-api` |
 
-`npm run dev` loads `.env.development`, which points both at the relative prefixes; the `server.proxy` entries in `vite.config.js` forward them to the real APIs server-side, so the browser sees same-origin requests and CORS never applies. Production builds and Vitest (mode `test`) don't load `.env.development`, so both use the absolute origins. Override either with a git-ignored `.env.local`.
+`npm run dev` loads `.env.development`, which points both at the relative prefixes; the `server.proxy` entries in `vite.config.js` forward them to the real APIs server-side, so the browser sees same-origin requests and CORS never applies. Production builds and Vitest (mode `test`) don't load `.env.development`, so both use the absolute origins.
+
+To override either locally, use a git-ignored **`.env.development.local`** — **not** `.env.local`. Vite ranks a mode-specific file above a generic one, so `.env.development` beats `.env.local` and any value set there is silently ignored in dev. Both `.local` names are already covered by the `*.local` entry in `.gitignore`.
 
 Only the dashboard API actually *requires* this: it sends `Access-Control-Allow-Origin: https://sh3r4rd.com` (from `cors_allowed_origin`), so direct calls from `localhost:5173` are blocked. The requests API sends `Access-Control-Allow-Origin: *` and is proxied only for consistency.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,21 @@ Personal portfolio website (sh3r4rd.com) built with React, Tailwind CSS, and Vit
 - **Deploy (manual):** `make deploy bucket=<bucket-name>` (builds then syncs to S3)
 - **Preview production build:** `npm run preview`
 
+#### API base URLs (and the dev proxy)
+
+`src/lib/api.js` is the single source of truth for both backend origins — never hardcode them in a component:
+
+| Export | Env var | Default (prod) | Dev proxy prefix |
+| --- | --- | --- | --- |
+| `API_BASE` | `VITE_API_BASE_URL` | `https://dashboard-api.sh3r4rd.com` | `/dashboard-api` |
+| `REQUESTS_API_BASE` | `VITE_REQUESTS_API_BASE_URL` | `https://api.sh3r4rd.com` | `/requests-api` |
+
+`npm run dev` loads `.env.development`, which points both at the relative prefixes; the `server.proxy` entries in `vite.config.js` forward them to the real APIs server-side, so the browser sees same-origin requests and CORS never applies. Production builds and Vitest (mode `test`) don't load `.env.development`, so both use the absolute origins. Override either with a git-ignored `.env.local`.
+
+Only the dashboard API actually *requires* this: it sends `Access-Control-Allow-Origin: https://sh3r4rd.com` (from `cors_allowed_origin`), so direct calls from `localhost:5173` are blocked. The requests API sends `Access-Control-Allow-Origin: *` and is proxied only for consistency.
+
+**Submitting the resume form locally POSTs to the real production `/requests` endpoint and creates a real request.** Point `VITE_REQUESTS_API_BASE_URL` at a stub to avoid that.
+
 ### Backend (Go Lambda)
 
 - **Build all Lambdas:** `make build-lambdas`
@@ -127,7 +142,7 @@ SES receives email → stores raw email in S3 → triggers email-parser Lambda �
 
 ### Backend API
 
-- Resume request form POSTs to `https://api.sh3r4rd.com/requests`
+- Resume request form POSTs to `${REQUESTS_API_BASE}/requests` (`https://api.sh3r4rd.com/requests` in production — see "API base URLs" above)
 - Payload fields: `firstName`, `lastName`, `email`, `phone`, `company`, `jobTitle`, `description`
 - Backend infrastructure is defined in `infra/recruiter-dashboard/`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,9 +1762,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1779,9 +1776,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1796,9 +1790,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1813,9 +1804,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1830,9 +1818,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1847,9 +1832,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1864,9 +1846,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1881,9 +1860,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1898,9 +1874,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1915,9 +1888,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1932,9 +1902,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1949,9 +1916,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1966,9 +1930,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3338,9 +3299,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,19 @@
+// Base URL for the recruiter dashboard API.
+//
+// Production builds talk to the API's own origin directly. That API only sends
+// `Access-Control-Allow-Origin: https://sh3r4rd.com` (see `cors_allowed_origin`
+// in infra/recruiter-dashboard), so a browser on http://localhost:5173 has its
+// responses blocked. `npm run dev` therefore sets VITE_API_BASE_URL to the
+// relative `/dashboard-api` prefix (.env.development), which the Vite dev server
+// proxies to the real API — same-origin from the browser's view, so CORS never
+// applies. Point at any other backend with VITE_API_BASE_URL in `.env.local`.
+export const API_BASE = import.meta.env.VITE_API_BASE_URL || "https://dashboard-api.sh3r4rd.com";
+
+// Base URL for the resume-request API (the /requests endpoint the resume form
+// POSTs to). This is a different API from the dashboard one above and it does
+// send `Access-Control-Allow-Origin: *`, so localhost is not actually blocked —
+// it is routed through the same dev proxy purely for consistency, so both APIs
+// are configured in one place and neither depends on the CORS headers of a
+// specific response. Same env-var mechanics as API_BASE.
+export const REQUESTS_API_BASE =
+  import.meta.env.VITE_REQUESTS_API_BASE_URL || "https://api.sh3r4rd.com";

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -6,8 +6,14 @@
 // responses blocked. `npm run dev` therefore sets VITE_API_BASE_URL to the
 // relative `/dashboard-api` prefix (.env.development), which the Vite dev server
 // proxies to the real API — same-origin from the browser's view, so CORS never
-// applies. Point at any other backend with VITE_API_BASE_URL in `.env.local`.
-export const API_BASE = import.meta.env.VITE_API_BASE_URL || "https://dashboard-api.sh3r4rd.com";
+// applies. Point at any other backend with VITE_API_BASE_URL in a git-ignored
+// `.env.development.local` — NOT `.env.local`, which Vite ranks *below* the
+// mode-specific `.env.development` and which therefore cannot override it here.
+//
+// `??`, not `||`, so an explicit empty value is honored: VITE_API_BASE_URL= is
+// the natural way to say "same origin as the page" and must not silently fall
+// back to production.
+export const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "https://dashboard-api.sh3r4rd.com";
 
 // Base URL for the resume-request API (the /requests endpoint the resume form
 // POSTs to). This is a different API from the dashboard one above and it does
@@ -16,4 +22,4 @@ export const API_BASE = import.meta.env.VITE_API_BASE_URL || "https://dashboard-
 // are configured in one place and neither depends on the CORS headers of a
 // specific response. Same env-var mechanics as API_BASE.
 export const REQUESTS_API_BASE =
-  import.meta.env.VITE_REQUESTS_API_BASE_URL || "https://api.sh3r4rd.com";
+  import.meta.env.VITE_REQUESTS_API_BASE_URL ?? "https://api.sh3r4rd.com";

--- a/src/mocks/__tests__/mocks.test.js
+++ b/src/mocks/__tests__/mocks.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { createRecruiter, RECRUITERS, STATS, buildStats } from '../fixtures'
 import { API_BASE } from '../handlers'
+import { REQUESTS_API_BASE } from '../../lib/api'
 
 // Validates the test infrastructure itself (issue #38): deterministic fixtures
 // and a live MSW server (started by setup.js) that serves the mock endpoints.
@@ -55,5 +56,19 @@ describe('MSW server', () => {
     const res = await fetch(`${API_BASE}/stats`)
     expect(res.ok).toBe(true)
     await expect(res.json()).resolves.toEqual(STATS)
+  })
+})
+
+// The mocks derive their base from src/lib/api.js so they can never drift from
+// the URLs the app actually calls. That removes the guard the old duplicated
+// literal gave us: every handler would follow a wrong base in lockstep and the
+// suite would stay green while production was broken. These assertions restore
+// it by pinning the values themselves rather than re-stating them in the mocks.
+describe('API base URLs', () => {
+  it('resolve to the production origins under test/production mode', () => {
+    // A dev-only proxy prefix reaching here means .env.development leaked out of
+    // mode=development — the exact failure that would ship a relative URL to S3.
+    expect(API_BASE).toBe('https://dashboard-api.sh3r4rd.com')
+    expect(REQUESTS_API_BASE).toBe('https://api.sh3r4rd.com')
   })
 })

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -1,11 +1,14 @@
 import { http, HttpResponse } from 'msw'
 import { RECRUITERS, STATS } from './fixtures'
+import { API_BASE } from '../lib/api'
 
-// Base URL of the production API the dashboard talks to. The dashboard
-// hardcodes this origin (no env var), so the mocks target it directly.
+// Re-exported so tests keep importing the base from here. It comes from the app
+// itself, so mocks can never drift from the URLs the dashboard actually calls.
+// Under Vitest (mode=test) VITE_API_BASE_URL is unset, so this is the real API
+// origin — the dev-only proxy prefix never reaches tests.
 // Note: the dashboard API lives on its own subdomain; the resume form's
 // /requests endpoint is a separate API on api.sh3r4rd.com and is not mocked here.
-export const API_BASE = 'https://dashboard-api.sh3r4rd.com'
+export { API_BASE }
 
 // Default happy-path handlers. Tests override these per-case with
 // `server.use(...)` to simulate errors, empty results, or custom datasets.

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -6,9 +6,10 @@ import StatsCards from "../components/sections/StatsCards";
 import FilterBar from "../components/sections/FilterBar";
 import RecruiterTable from "../components/sections/RecruiterTable";
 import { EMPTY_FILTERS } from "../lib/filters";
+import { API_BASE } from "../lib/api";
 
-const RECRUITERS_URL = "https://dashboard-api.sh3r4rd.com/recruiters";
-const STATS_URL = "https://dashboard-api.sh3r4rd.com/stats";
+const RECRUITERS_URL = `${API_BASE}/recruiters`;
+const STATS_URL = `${API_BASE}/stats`;
 const PAGE_SIZE = 10;
 
 function matchesFilters(item, filters) {

--- a/src/pages/ResumeRequestPage.jsx
+++ b/src/pages/ResumeRequestPage.jsx
@@ -4,6 +4,7 @@ import { CheckCircle2 } from "lucide-react";
 import { Button } from "../components/ui/button";
 import { Card, CardContent } from "../components/ui/card";
 import PageLayout from "../components/layout/PageLayout";
+import { REQUESTS_API_BASE } from "../lib/api";
 
 // Single source of truth for validation rules shared by the form, the live
 // word counter, and the error messages.
@@ -120,7 +121,7 @@ export default function ResumeRequestPage() {
       description: form.description.value,
     };
 
-    fetch("https://api.sh3r4rd.com/requests", {
+    fetch(`${REQUESTS_API_BASE}/requests`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,27 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      // The dashboard API only allows the https://sh3r4rd.com origin, so calls
+      // made straight from http://localhost:5173 are blocked by CORS. In dev the
+      // app targets this relative prefix instead (VITE_API_BASE_URL in
+      // .env.development) and the dev server forwards the request server-side,
+      // where CORS does not apply. `changeOrigin` rewrites the Host header so
+      // the API Gateway custom domain routes the request.
+      '/dashboard-api': {
+        target: 'https://dashboard-api.sh3r4rd.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/dashboard-api/, ''),
+      },
+      // The resume form's /requests endpoint, on a separate API. That one does
+      // allow any origin, so this proxy is for consistency rather than to unblock
+      // it — both API bases are wired the same way and configured in one place.
+      '/requests-api': {
+        target: 'https://api.sh3r4rd.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/requests-api/, ''),
+      },
+    },
+  },
 })


### PR DESCRIPTION
Closes #109.

`/dashboard` could not be developed locally — every API call from `http://localhost:5173` was rejected by the browser, so the page rendered its error state while working correctly in production. Testing dashboard changes meant deploying first.

## Root cause

The API allows exactly one origin, and it is the production domain. `cors_allowed_origin` (`variables.tf:38`) is a single string, passed to the Lambda as `CORS_ALLOW_ORIGIN` (`main.tf:103`) and echoed verbatim on every response (`handler.go:403`); the three API Gateway `OPTIONS` mock integrations hardcode the same value.

The responses returned **HTTP 200** — the browser then discarded them because the origin didn't match. This was never a Lambda, IAM, or routing failure.

## Approach

Route dev-server calls through a **Vite proxy**: the browser issues a same-origin request to `localhost:5173`, so CORS never applies, and the dev server forwards to the real API server-side where it isn't enforced. No infra change, no redeploy, no change to the production surface.

Adding `http://localhost:5173` to `cors_allowed_origin` was rejected — it would require a list variable, multi-origin echo logic in both the Lambda and three mock integrations, and production permanently advertising a localhost origin.

`src/lib/api.js` is now the single source of truth for both backend origins, defaulting to the production hosts so a missing env file degrades to today's behavior rather than a broken build. `.env.development` is loaded only in mode `development` — production builds and Vitest (mode `test`) keep the absolute origins, which is what lets MSW's absolute-URL handlers keep matching **with no test changes**.

`changeOrigin: true` is required, not cosmetic: both APIs sit behind API Gateway custom domains that route on the `Host` header.

## Note on the resume form

The resume API is included for **consistency only** — it returns `Access-Control-Allow-Origin: *` and was never blocked from localhost:

```console
$ curl -s -I -X OPTIONS https://api.sh3r4rd.com/requests \
    -H "Origin: http://localhost:5173" -H "Access-Control-Request-Method: POST" | grep -i allow-origin
access-control-allow-origin: *
```

⚠️ Submitting the form locally still POSTs to the **real production** `/requests` endpoint and creates a real request — true before this PR too. `VITE_REQUESTS_API_BASE_URL` in a `.env.local` points it at a stub. Documented in both `CLAUDE.md` and `.env.development`.

## Verification

- `/dashboard` renders live data locally (16 requests, 16 companies) with **zero** CORS errors; both requests proxied and 200. Only console errors left are Google Analytics beacons aborting in headless — pre-existing and unrelated.
- Requests proxy returns the upstream `403 MissingAuthenticationToken` unchanged for a `GET`, proving the path rewrite and `Host` routing reach API Gateway. Used `GET` deliberately — a `POST` would have created a real resume request. (`curl -X OPTIONS` against the dev server proves nothing: Vite answers preflights itself and never forwards them.)
- Production bundle contains both absolute origins and **neither** proxy prefix, so deploys are unaffected.
- `npm run lint` clean · `npm test` 43 passed · `npm run test:e2e` 17 passed / 5 skipped · `npm run build` clean.
- `make ci` passes end to end (exit 0): `lint`, `build`, `test-go`, `tf-fmt-check`, `tf-init`, `tf-validate` — "The configuration is valid." No file under `infra/` is touched.

## Files

| File | Change |
| --- | --- |
| `src/lib/api.js` | **new** — `API_BASE` + `REQUESTS_API_BASE` |
| `.env.development` | **new** — dev-only proxy prefixes, committed |
| `vite.config.js` | `server.proxy` entries for both APIs |
| `src/pages/DashboardPage.jsx` | use `API_BASE` |
| `src/pages/ResumeRequestPage.jsx` | use `REQUESTS_API_BASE` |
| `src/mocks/handlers.js` | re-export `API_BASE` from the app so mocks can't drift |
| `CLAUDE.md` | document both bases, the proxy, and the prod-POST warning |

`.env.local` is already covered by the `*.local` entry in `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
